### PR TITLE
Added the CimSession to the schema

### DIFF
--- a/DSCResources/MSFT_xDnsServerADZone/MSFT_xDnsServerADZone.schema.mof
+++ b/DSCResources/MSFT_xDnsServerADZone/MSFT_xDnsServerADZone.schema.mof
@@ -8,4 +8,5 @@ class MSFT_xDnsServerADZone : OMI_BaseResource
     [Write, Description("DNS Server name")] String ComputerName;
     [Write, Description("Credential used to set zone"), EmbeddedInstance("MSFT_Credential")] String Credential;
     [Write, Description("Whether the DNS zone should be available or removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Read] String CimSession;
 };


### PR DESCRIPTION
When running a Get-DSCConfiguration it crashes because the HashTable returns a value (CimSession) not matching the schema.mof.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdnsserver/44)
<!-- Reviewable:end -->
