### PR TITLE
add DnsServer attribute to xDNSRecord fixes #42

### DIFF
--- a/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.psm1
+++ b/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.psm1
@@ -94,10 +94,14 @@ function Set-TargetResource
 
         [ValidateSet('Present','Absent')]
         [System.String]
-        $Ensure = 'Present'
+        $Ensure = 'Present',
+
+        [ValidateScript({Test-Connection $_ -quiet })]
+        [System.String]
+        $DnsServer = "localhost"
     )
 
-    $DNSParameters = @{ Name = $Name; ZoneName = $Zone; } 
+    $DNSParameters = @{ Name = $Name; ZoneName = $Zone; ComputerName = $DnsServer} 
 
     if ($Ensure -eq 'Present')
     {

--- a/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.psm1
+++ b/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.psm1
@@ -38,7 +38,11 @@ function Get-TargetResource
 
         [ValidateSet('Present','Absent')]
         [System.String]
-        $Ensure = 'Present'
+        $Ensure = 'Present',
+
+        [ValidateScript({Test-Connection $_ -quiet })]
+        [System.String]
+        $DnsServer = "localhost"
     )
 
     Write-Verbose -Message ($LocalizedData.GettingDnsRecordMessage -f $Name, $Type, $Zone)
@@ -162,7 +166,11 @@ function Test-TargetResource
 
         [ValidateSet('Present','Absent')]
         [System.String]
-        $Ensure = 'Present'
+        $Ensure = 'Present',
+
+        [ValidateScript({Test-Connection $_ -quiet })]
+        [System.String]
+        $DnsServer = "localhost"
     )
 
     $result = @(Get-TargetResource @PSBoundParameters)

--- a/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.psm1
+++ b/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.psm1
@@ -40,7 +40,6 @@ function Get-TargetResource
         [System.String]
         $Ensure = 'Present',
 
-        [ValidateScript({Test-Connection $_ -quiet })]
         [System.String]
         $DnsServer = "localhost"
     )
@@ -100,7 +99,6 @@ function Set-TargetResource
         [System.String]
         $Ensure = 'Present',
 
-        [ValidateScript({Test-Connection $_ -quiet })]
         [System.String]
         $DnsServer = "localhost"
     )
@@ -125,7 +123,6 @@ function Set-TargetResource
     elseif ($Ensure -eq 'Absent')
     {
         
-        $DNSParameters.Add('Computername','localhost')
         $DNSParameters.Add('Force',$true)
 
         if ($Type -eq "ARecord")
@@ -168,7 +165,6 @@ function Test-TargetResource
         [System.String]
         $Ensure = 'Present',
 
-        [ValidateScript({Test-Connection $_ -quiet })]
         [System.String]
         $DnsServer = "localhost"
     )

--- a/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.schema.mof
+++ b/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.schema.mof
@@ -6,5 +6,6 @@ class MSFT_xDnsRecord : OMI_BaseResource
     [Required, ValueMap{"ARecord","CName"}, Values{"ARecord","CName"}] string Type;
     [Key] string Target;
     [Write, Description("Should this DNS resource record be present or absent"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Specifies the DNS Server instance to use to perform the task.")] String DnsServer;
 };
 

--- a/README.md
+++ b/README.md
@@ -79,13 +79,15 @@ Values include: { None | Any | Named | Specific }
 * **Type**: DNS Record Type.
 Values include: { ARecord | CName }
 * **Ensure**: Whether the host record should be present or removed
-
+* **DnsServer**: The DNS server to connect to, in order to register the DNS record.
+ * If you do not specify this parameter, localhost is used.
 
 ## Versions
 
 ### Unreleased
 
 * Converted AppVeyor.yml to pull Pester from PSGallery instead of Chocolatey
+* MSFT_xDNSRecord: Added DnsServer attribute to allow record to be created against a remote DNS server
 
 ### 1.7.0.0
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ configuration Sample_Set_Forwarders
     Import-DscResource -module xDnsServer
     xDnsServerForwarder SetForwarders
     {
-    	IsSingleInstance = 'Yes'
+        IsSingleInstance = 'Yes'
         IPAddresses = '192.168.0.10','192.168.0.11'
     }
 }
@@ -289,7 +289,7 @@ configuration Sample_Arecord
         Name = "testArecord"
         Target = "192.168.0.123"
         Zone = "contoso.com"
-	    Type = "ARecord"
+        Type = "ARecord"
         Ensure = "Present"
     }
 }
@@ -307,7 +307,7 @@ configuration Sample_RoundRobin_Arecord
         Name = "testArecord"
         Target = "192.168.0.123"
         Zone = "contoso.com"
-	    Type = "ARecord"
+        Type = "ARecord"
         Ensure = "Present"
     }
     xDnsRecord TestRecord2
@@ -315,7 +315,7 @@ configuration Sample_RoundRobin_Arecord
         Name = "testArecord"
         Target = "192.168.0.124"
         Zone = "contoso.com"
-	    Type = "ARecord"
+        Type = "ARecord"
         Ensure = "Present"
     }
 
@@ -334,7 +334,7 @@ configuration Sample_CName
         Name = "testCName"
         Target = "test.contoso.com"
         Zone = "contoso.com"
-	    Type = "CName"
+        Type = "CName"
         Ensure = "Present"
     }
 }
@@ -352,7 +352,7 @@ configuration Sample_Remove_Record
         Name = "testArecord"
         Target = "192.168.0.123"
         Zone = "contoso.com"
-	    Type = "ARecord"
+        Type = "ARecord"
         Ensure = "Absent"
     }
 }

--- a/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
@@ -67,10 +67,10 @@ try
                 (Get-TargetResource @testPresentParams).Ensure | Should Be 'Absent'
             } 
 
-            It "Calls 'Get-DnsServerResourceRecord' with 'DnsServer' parameter when 'DnsServer' specified" {
+            It "Calls 'Get-DnsServerResourceRecord' with 'ComputerName' parameter when 'DnsServer' specified" {
                 Mock Get-DnsServerResourceRecord -ParameterFilter { $DnsServer -eq $testDomainController } -MockWith { return [PSCustomObject] $fakeDnsServerResourceRecord; }
 
-                (Get-TargetResource @testPresentParams -DnsServer $testDomainController).DnsServer | Should Be $testDomainController;
+                (Get-TargetResource @testPresentParams -DnsServer $testDomainController).ComputerName | Should Be $testDomainController;
 
                 Assert-MockCalled Get-DnsServerResourceRecord -ParameterFilter { $DnsServer -eq $testDomainController } -Scope It;
             }        

--- a/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
@@ -144,6 +144,19 @@ try
                 Test-TargetResource @testPresentParams | Should Be $true
             }
 
+            It "Passes when a DnsServer which is not localhost is supplied (Issue #42)" {
+                Mock Get-TargetResource { 
+                    return @{
+                        Name = $testPresentParams.Name
+                        Zone = $testPresentParams.Zone
+                        Target = $testPresentParams.Target
+                        Ensure = $testPresentParams.Ensure
+                        DnsServer = $testDomainController
+                    }
+                }
+                Test-TargetResource @testPresentParams -DnsServer $testDomainController | Should Be $true
+            }
+
             It "Passes when record does not exist and Ensure is Absent" {
                 Mock Get-TargetResource { return $testAbsentParams } 
                 Test-TargetResource @testAbsentParams | Should Be $true

--- a/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
@@ -32,6 +32,7 @@ try
             Target = "192.168.0.1"
             Type = "ARecord"
             Ensure = "Present"
+            DnsServer = "localhost"
         }
         $testAbsentParams = @{
             Name = $testPresentParams.Name
@@ -39,6 +40,7 @@ try
             Target = $testPresentParams.Target
             Type = $testPresentParams.Type
             Ensure = "Absent"
+            DnsServer = "localhost"
         }
         $fakeDnsServerResourceRecord = @{
             HostName = $testPresentParams.Name;
@@ -68,11 +70,11 @@ try
             } 
 
             It "Calls 'Get-DnsServerResourceRecord' with 'Server' parameter when 'DnsServer' specified" {
-                Mock Get-DnsServerResourceRecord -ParameterFilter { $Server -eq $testDomainController } -MockWith { return [PSCustomObject] $fakeDnsServerResourceRecord; }
+                Mock Get-DnsServerResourceRecord -ParameterFilter { $DnsServer -eq $testDomainController } -MockWith { return [PSCustomObject] $fakeDnsServerResourceRecord; }
 
                 Get-TargetResource @testPresentParams -DnsServer $testDomainController;
 
-                Assert-MockCalled Get-DnsServerResourceRecord -ParameterFilter { $Server -eq $testDomainController } -Scope It;
+                Assert-MockCalled Get-DnsServerResourceRecord -ParameterFilter { $DnsServer -eq $testDomainController } -Scope It;
             }        
         }
         #endregion

--- a/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
@@ -50,6 +50,8 @@ try
                 }
             }
         }
+
+        $testDomainController = 'TESTDC';
         #endregion
 
         #region Function Get-TargetResource
@@ -64,7 +66,14 @@ try
                 Mock Get-DnsServerResourceRecord { return $null }
                 (Get-TargetResource @testPresentParams).Ensure | Should Be 'Absent'
             } 
-        
+
+            It "Calls 'Get-DnsServerResourceRecord' with 'Server' parameter when 'DnsServer' specified" {
+                Mock Get-DnsServerResourceRecord -ParameterFilter { $Server -eq $testDomainController } -MockWith { return [PSCustomObject] $fakeDnsServerResourceRecord; }
+
+                Get-TargetResource @testPresentParams -DnsServer $testDomainController;
+
+                Assert-MockCalled Get-DnsServerResourceRecord -ParameterFilter { $Server -eq $testDomainController } -Scope It;
+            }        
         }
         #endregion
 

--- a/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
@@ -66,14 +66,7 @@ try
                 Mock Get-DnsServerResourceRecord { return $null }
                 (Get-TargetResource @testPresentParams).Ensure | Should Be 'Absent'
             } 
-
-            It "Calls 'Get-DnsServerResourceRecord' with 'ComputerName' parameter when 'DnsServer' specified" {
-                Mock Get-DnsServerResourceRecord -ParameterFilter { $DnsServer -eq $testDomainController } -MockWith { return [PSCustomObject] $fakeDnsServerResourceRecord; }
-
-                (Get-TargetResource @testPresentParams -DnsServer $testDomainController).ComputerName | Should Be $testDomainController;
-
-                Assert-MockCalled Get-DnsServerResourceRecord -ParameterFilter { $DnsServer -eq $testDomainController } -Scope It;
-            }        
+     
         }
         #endregion
 

--- a/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
@@ -32,7 +32,6 @@ try
             Target = "192.168.0.1"
             Type = "ARecord"
             Ensure = "Present"
-            DnsServer = "localhost"
         }
         $testAbsentParams = @{
             Name = $testPresentParams.Name
@@ -40,7 +39,6 @@ try
             Target = $testPresentParams.Target
             Type = $testPresentParams.Type
             Ensure = "Absent"
-            DnsServer = "localhost"
         }
         $fakeDnsServerResourceRecord = @{
             HostName = $testPresentParams.Name;
@@ -69,7 +67,7 @@ try
                 (Get-TargetResource @testPresentParams).Ensure | Should Be 'Absent'
             } 
 
-            It "Calls 'Get-DnsServerResourceRecord' with 'Server' parameter when 'DnsServer' specified" {
+            It "Calls 'Get-DnsServerResourceRecord' with 'DnsServer' parameter when 'DnsServer' specified" {
                 Mock Get-DnsServerResourceRecord -ParameterFilter { $DnsServer -eq $testDomainController } -MockWith { return [PSCustomObject] $fakeDnsServerResourceRecord; }
 
                 Get-TargetResource @testPresentParams -DnsServer $testDomainController;

--- a/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
@@ -70,7 +70,7 @@ try
             It "Calls 'Get-DnsServerResourceRecord' with 'DnsServer' parameter when 'DnsServer' specified" {
                 Mock Get-DnsServerResourceRecord -ParameterFilter { $DnsServer -eq $testDomainController } -MockWith { return [PSCustomObject] $fakeDnsServerResourceRecord; }
 
-                Get-TargetResource @testPresentParams -DnsServer $testDomainController;
+                (Get-TargetResource @testPresentParams -DnsServer $testDomainController).DnsServer | Should Be $testDomainController;
 
                 Assert-MockCalled Get-DnsServerResourceRecord -ParameterFilter { $DnsServer -eq $testDomainController } -Scope It;
             }        


### PR DESCRIPTION
A simple fix as suggested by the issue record.

I assume that the base "PSDSCCredential" mechanism is the preferred way to pass in credentials, thus have not created a 'Credential' attribute.  Is that correct, or does this create an unwanted dependency with WMF5?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdnsserver/46)
<!-- Reviewable:end -->
