### PR TITLE
xDnsServerForwarder: Added Error Handling for xDnsServerForwarder

### DIFF
--- a/DSCResources/MSFT_xDnsServerForwarder/MSFT_xDnsServerForwarder.psm1
+++ b/DSCResources/MSFT_xDnsServerForwarder/MSFT_xDnsServerForwarder.psm1
@@ -85,17 +85,23 @@ function Test-TargetResource
         [string[]]
         $IPAddresses
     )
+    Write-Verbose -Message 'Getting current resource state.'
     [array]$currentIPs = (Get-TargetResource @PSBoundParameters).IPAddresses
+    Write-Verbose -Message 'Verifying the currnet state is correct.'
     if ($currentIPs.Count -ne $IPAddresses.Count)
     {
+        Write-Verbose -Message 'The current state is incorrect.'
         return $false
     }
     foreach ($ip in $IPAddresses)
     {
+        Write-Verbose -Message 'Checking the current forwarders.'
         if ($ip -notin $currentIPs)
         {
+            Write-Verbose -Message 'The current state is incorrect.'
             return $false
         }
     }
+    Write-Verbose -Message 'The current state is correct.'
     return $true
 }

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Values include: { ARecord | CName }
 
 ### Unreleased
 
+* xDnsServerForwarder
+    * Added error handling to functions
 * Converted AppVeyor.yml to pull Pester from PSGallery instead of Chocolatey
 
 ### 1.7.0.0

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ configuration Sample_Set_Forwarders
     Import-DscResource -module xDnsServer
     xDnsServerForwarder SetForwarders
     {
-    	IsSingleInstance = 'Yes'
+        IsSingleInstance = 'Yes'
         IPAddresses = '192.168.0.10','192.168.0.11'
     }
 }
@@ -289,7 +289,7 @@ configuration Sample_Arecord
         Name = "testArecord"
         Target = "192.168.0.123"
         Zone = "contoso.com"
-	    Type = "ARecord"
+        Type = "ARecord"
         Ensure = "Present"
     }
 }
@@ -307,7 +307,7 @@ configuration Sample_RoundRobin_Arecord
         Name = "testArecord"
         Target = "192.168.0.123"
         Zone = "contoso.com"
-	    Type = "ARecord"
+        Type = "ARecord"
         Ensure = "Present"
     }
     xDnsRecord TestRecord2
@@ -315,7 +315,7 @@ configuration Sample_RoundRobin_Arecord
         Name = "testArecord"
         Target = "192.168.0.124"
         Zone = "contoso.com"
-	    Type = "ARecord"
+        Type = "ARecord"
         Ensure = "Present"
     }
 
@@ -334,7 +334,7 @@ configuration Sample_CName
         Name = "testCName"
         Target = "test.contoso.com"
         Zone = "contoso.com"
-	    Type = "CName"
+        Type = "CName"
         Ensure = "Present"
     }
 }
@@ -352,7 +352,7 @@ configuration Sample_Remove_Record
         Name = "testArecord"
         Target = "192.168.0.123"
         Zone = "contoso.com"
-	    Type = "ARecord"
+        Type = "ARecord"
         Ensure = "Absent"
     }
 }


### PR DESCRIPTION
I've added try catch blocks to the get and set functions in the resource.

When an error is generated in the get function an empty string array will be returned for the IPAddress property in the hashtable.

I also added some verbose output in the event of a failure for the set function. The set function will still throw an error if it fails to set the resource; I'm not sure if this is best practice so please inform me if this should be handled differently.

Additionally I did some touch up on the code to bring it into adherence with the style guide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdnsserver/48)
<!-- Reviewable:end -->
