### PR TITLE
xDnsServerADZone: Removed CimSession from Get-TargetResource return value (Fixes #40)

### DIFF
--- a/DSCResources/MSFT_xDnsServerADZone/MSFT_xDnsServerADZone.psm1
+++ b/DSCResources/MSFT_xDnsServerADZone/MSFT_xDnsServerADZone.psm1
@@ -69,7 +69,6 @@ function Get-TargetResource
         ReplicationScope = $dnsServerZone.ReplicationScope
         DirectoryPartitionName = $dnsServerZone.DirectoryPartitionName
         Ensure = if ($dnsServerZone -eq $null) { 'Absent' } else { 'Present' }
-        CimSession = $cimSession
     }
     return $targetResource
 } #end function Get-TargetResource

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ configuration Sample_Set_Forwarders
     Import-DscResource -module xDnsServer
     xDnsServerForwarder SetForwarders
     {
-    	IsSingleInstance = 'Yes'
+        IsSingleInstance = 'Yes'
         IPAddresses = '192.168.0.10','192.168.0.11'
     }
 }
@@ -288,7 +288,7 @@ configuration Sample_Arecord
         Name = "testArecord"
         Target = "192.168.0.123"
         Zone = "contoso.com"
-	    Type = "ARecord"
+        Type = "ARecord"
         Ensure = "Present"
     }
 }
@@ -306,7 +306,7 @@ configuration Sample_RoundRobin_Arecord
         Name = "testArecord"
         Target = "192.168.0.123"
         Zone = "contoso.com"
-	    Type = "ARecord"
+        Type = "ARecord"
         Ensure = "Present"
     }
     xDnsRecord TestRecord2
@@ -314,7 +314,7 @@ configuration Sample_RoundRobin_Arecord
         Name = "testArecord"
         Target = "192.168.0.124"
         Zone = "contoso.com"
-	    Type = "ARecord"
+        Type = "ARecord"
         Ensure = "Present"
     }
 
@@ -333,7 +333,7 @@ configuration Sample_CName
         Name = "testCName"
         Target = "test.contoso.com"
         Zone = "contoso.com"
-	    Type = "CName"
+        Type = "CName"
         Ensure = "Present"
     }
 }
@@ -351,7 +351,7 @@ configuration Sample_Remove_Record
         Name = "testArecord"
         Target = "192.168.0.123"
         Zone = "contoso.com"
-	    Type = "ARecord"
+        Type = "ARecord"
         Ensure = "Absent"
     }
 }

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Values include: { ARecord | CName }
 ### Unreleased
 
 * Converted AppVeyor.yml to pull Pester from PSGallery instead of Chocolatey
+* Fixed bug in xDnsServerADZone causing Get-TargetResource to fail with an extra property.
 
 ### 1.7.0.0
 

--- a/Tests/Unit/MSFT_xDnsServerADZone.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerADZone.Tests.ps1
@@ -66,9 +66,12 @@ try
 
             Mock -CommandName 'Assert-Module' -MockWith { }
 
-            It 'Returns a "System.Collections.Hashtable" object type' {
+            It 'Returns a "System.Collections.Hashtable" object type with schema properties' {
                 $targetResource = Get-TargetResource @testParams -ReplicationScope $testReplicationScope;
                 $targetResource -is [System.Collections.Hashtable] | Should Be $true;
+
+                $schemaFields = @('Name', 'DynamicUpdate', 'ReplicationScope', 'DirectoryPartitionName', 'Ensure');
+                ($Null -eq ($targetResource.Keys.GetEnumerator() | Where-Object -FilterScript { $schemaFields -notcontains $_ })) | Should Be $true;
             }
 
             It 'Returns "Present" when DNS zone exists and "Ensure" = "Present"' {


### PR DESCRIPTION
Fix for PowerShell/xDnsServer#40

Added fix, updated unreleased changes and added unit test.

When checking other resources such as xDnsServerPrimaryZone and xDnsServerSecondaryZone they also did not return a CimSession key. I have removed CimSession from the return of Get-TargetResource within xDnsServerADZone for consistency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdnsserver/49)
<!-- Reviewable:end -->
