### PR TITLE
Add resource xDnsServerZoneAging

### DIFF
--- a/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.psm1
+++ b/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.psm1
@@ -93,33 +93,39 @@ function Set-TargetResource
     }
 
     # Update the refresh interval
-    if ($currentConfiguration.RefreshInterval -ne $RefreshInterval)
+    if ($PSBoundParameters.ContainsKey('RefreshInterval'))
     {
-        Write-Verbose -Message "Set DNS zone refresh interval to $RefreshInterval hours."
+        if ($currentConfiguration.RefreshInterval -ne $RefreshInterval)
+        {
+            Write-Verbose -Message "Set DNS zone refresh interval to $RefreshInterval hours."
 
-        $refreshIntervalTimespan = [System.TimeSpan]::FromHours($RefreshInterval)
+            $refreshIntervalTimespan = [System.TimeSpan]::FromHours($RefreshInterval)
 
-        <#
-            Hide the following warning if aging is not enabled: Specified
-            parameters related to aging of records have been set. However,
-            aging was not enabled and hence the settings are ineffective.
-        #>
-        Set-DnsServerZoneAging -Name $Name -RefreshInterval $refreshIntervalTimespan -WarningAction 'SilentlyContinue'
+            <#
+                Hide the following warning if aging is not enabled: Specified
+                parameters related to aging of records have been set. However,
+                aging was not enabled and hence the settings are ineffective.
+            #>
+            Set-DnsServerZoneAging -Name $Name -RefreshInterval $refreshIntervalTimespan -WarningAction 'SilentlyContinue'
+        }
     }
 
     # Update the no refresh interval
-    if ($currentConfiguration.NoRefreshInterval -ne $NoRefreshInterval)
+    if ($PSBoundParameters.ContainsKey('NoRefreshInterval'))
     {
-        Write-Verbose -Message "Set DNS zone no refresh interval to $NoRefreshInterval hours."
+        if ($currentConfiguration.NoRefreshInterval -ne $NoRefreshInterval)
+        {
+            Write-Verbose -Message "Set DNS zone no refresh interval to $NoRefreshInterval hours."
 
-        $noRefreshIntervalTimespan = [System.TimeSpan]::FromHours($NoRefreshInterval)
+            $noRefreshIntervalTimespan = [System.TimeSpan]::FromHours($NoRefreshInterval)
 
-        <#
-            Hide the following warning if aging is not enabled: Specified
-            parameters related to aging of records have been set. However,
-            aging was not enabled and hence the settings are ineffective.
-        #>
-        Set-DnsServerZoneAging -Name $Name -NoRefreshInterval $noRefreshIntervalTimespan -WarningAction 'SilentlyContinue'
+            <#
+                Hide the following warning if aging is not enabled: Specified
+                parameters related to aging of records have been set. However,
+                aging was not enabled and hence the settings are ineffective.
+            #>
+            Set-DnsServerZoneAging -Name $Name -NoRefreshInterval $noRefreshIntervalTimespan -WarningAction 'SilentlyContinue'
+        }
     }
 }
 
@@ -167,7 +173,17 @@ function Test-TargetResource
 
     $currentConfiguration = Get-TargetResource -Name $Name -AgingEnabled $AgingEnabled
 
-    return $currentConfiguration.AgingEnabled -eq $AgingEnabled -and
-           $currentConfiguration.RefreshInterval -eq $RefreshInterval -and
-           $currentConfiguration.NoRefreshInterval -eq $NoRefreshInterval
+    $isDesiredState = $currentConfiguration.AgingEnabled -eq $AgingEnabled
+
+    if ($PSBoundParameters.ContainsKey('RefreshInterval'))
+    {
+        $isDesiredState = $isDesiredState -and $currentConfiguration.RefreshInterval -eq $RefreshInterval
+    }
+
+    if ($PSBoundParameters.ContainsKey('NoRefreshInterval'))
+    {
+        $isDesiredState = $isDesiredState -and $currentConfiguration.NoRefreshInterval -eq $NoRefreshInterval
+    }
+
+    return $isDesiredState
 }

--- a/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.psm1
+++ b/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.psm1
@@ -24,7 +24,7 @@ function Get-TargetResource
         $AgingEnabled
     )
 
-    Write-Verbose -Message "Getting the DNS zone aging for $Name ..."
+    Write-Verbose -Message "Getting the DNS zone aging for $Name."
 
     # Get the current zone aging from the local DNS server
     $zoneAging = Get-DnsServerZoneAging -Name $Name
@@ -80,26 +80,45 @@ function Set-TargetResource
     # Enable or disable zone aging
     if ($currentConfiguration.AgingEnabled -ne $AgingEnabled)
     {
-        Write-Verbose -Message "$() DNS zone aging on $Name ..."
-        
+        if ($AgingEnabled)
+        {
+            Write-Verbose -Message "Enable DNS zone aging on $Name."
+        }
+        else
+        {
+            Write-Verbose -Message "Disable DNS zone aging on $Name."
+        }
+
         Set-DnsServerZoneAging -Name $Name -Aging $AgingEnabled -WarningAction 'SilentlyContinue'
     }
 
     # Update the refresh interval
     if ($currentConfiguration.RefreshInterval -ne $RefreshInterval)
     {
-        Write-Verbose -Message "Set DNS zone refresh interval to $RefreshInterval hours ..."
+        Write-Verbose -Message "Set DNS zone refresh interval to $RefreshInterval hours."
 
         $refreshIntervalTimespan = [System.TimeSpan]::FromHours($RefreshInterval)
+
+        <#
+            Hide the following warning if aging is not enabled: Specified
+            parameters related to aging of records have been set. However,
+            aging was not enabled and hence the settings are ineffective.
+        #>
         Set-DnsServerZoneAging -Name $Name -RefreshInterval $refreshIntervalTimespan -WarningAction 'SilentlyContinue'
     }
 
     # Update the no refresh interval
     if ($currentConfiguration.NoRefreshInterval -ne $NoRefreshInterval)
     {
-        Write-Verbose -Message "Set DNS zone no refresh interval to $NoRefreshInterval hours ..."
+        Write-Verbose -Message "Set DNS zone no refresh interval to $NoRefreshInterval hours."
 
         $noRefreshIntervalTimespan = [System.TimeSpan]::FromHours($NoRefreshInterval)
+
+        <#
+            Hide the following warning if aging is not enabled: Specified
+            parameters related to aging of records have been set. However,
+            aging was not enabled and hence the settings are ineffective.
+        #>
         Set-DnsServerZoneAging -Name $Name -NoRefreshInterval $noRefreshIntervalTimespan -WarningAction 'SilentlyContinue'
     }
 }
@@ -144,7 +163,7 @@ function Test-TargetResource
         $NoRefreshInterval = 168
     )
 
-    Write-Verbose -Message "Testing the DNS zone aging for $Name ..."
+    Write-Verbose -Message "Testing the DNS zone aging for $Name."
 
     $currentConfiguration = Get-TargetResource -Name $Name -AgingEnabled $AgingEnabled
 

--- a/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.psm1
+++ b/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.psm1
@@ -1,0 +1,154 @@
+
+<#
+    .SYNOPSIS
+        Get the DNS zone aging settings.
+
+    .PARAMETER Name
+        Name of the DNS zone.
+
+    .PARAMETER AgingEnabled
+        Option to enable scavenge stale resource records on the zone.
+#>
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [System.Boolean]
+        $AgingEnabled
+    )
+
+    Write-Verbose "Getting the DNS zone aging for $Name ..."
+
+    # Get the current zone aging from the local DNS server
+    $zoneAging = Get-DnsServerZoneAging -Name $Name
+
+    return @{
+        Name              = $Name
+        AgingEnabled      = $zoneAging.AgingEnabled
+        RefreshInterval   = $zoneAging.RefreshInterval.TotalHours
+        NoRefreshInterval = $zoneAging.NoRefreshInterval.TotalHours
+    }
+}
+
+<#
+    .SYNOPSIS
+        Set the DNS zone aging settings.
+
+    .PARAMETER Name
+        Name of the DNS zone.
+
+    .PARAMETER AgingEnabled
+        Option to enable scavenge stale resource records on the zone.
+
+    .PARAMETER RefreshInterval
+        Refresh interval for record scavencing in hours. Default value is 7 days.
+
+    .PARAMETER NoRefreshInterval
+        No-refresh interval for record scavencing in hours. Default value is 7 days.
+#>
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [System.Boolean]
+        $AgingEnabled,
+
+        [Parameter()]
+        [System.UInt32]
+        $RefreshInterval = 168,
+
+        [Parameter()]
+        [System.UInt32]
+        $NoRefreshInterval = 168
+    )
+
+    $currentConfiguration = Get-TargetResource -Name $Name -AgingEnabled $AgingEnabled
+
+    # Enable or disable zone aging
+    if ($currentConfiguration.AgingEnabled -ne $AgingEnabled)
+    {
+        Write-Verbose "$(if ($AgingEnabled) { 'Enable' } else { 'Disable' }) DNS zone aging on $Name ..."
+        
+        Set-DnsServerZoneAging -Name $Name -Aging $AgingEnabled -WarningAction 'SilentlyContinue'
+    }
+
+    # Update the refresh interval
+    if ($currentConfiguration.RefreshInterval -ne $RefreshInterval)
+    {
+        Write-Verbose "Set DNS zone refresh interval to $RefreshInterval hours ..."
+
+        $refreshIntervalTimespan = [System.TimeSpan]::FromHours($RefreshInterval)
+        Set-DnsServerZoneAging -Name $Name -RefreshInterval $refreshIntervalTimespan -WarningAction 'SilentlyContinue'
+    }
+
+    # Update the no refresh interval
+    if ($currentConfiguration.NoRefreshInterval -ne $NoRefreshInterval)
+    {
+        Write-Verbose "Set DNS zone no refresh interval to $NoRefreshInterval hours ..."
+
+        $noRefreshIntervalTimespan = [System.TimeSpan]::FromHours($NoRefreshInterval)
+        Set-DnsServerZoneAging -Name $Name -NoRefreshInterval $noRefreshIntervalTimespan -WarningAction 'SilentlyContinue'
+    }
+}
+
+<#
+    .SYNOPSIS
+        Test the DNS zone aging settings.
+
+    .PARAMETER Name
+        Name of the DNS zone.
+
+    .PARAMETER AgingEnabled
+        Option to enable scavenge stale resource records on the zone.
+
+    .PARAMETER RefreshInterval
+        Refresh interval for record scavencing in hours. Default value is 7 days.
+
+    .PARAMETER NoRefreshInterval
+        No-refresh interval for record scavencing in hours. Default value is 7 days.
+#>
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [System.Boolean]
+        $AgingEnabled,
+
+        [Parameter()]
+        [System.UInt32]
+        $RefreshInterval = 168,
+
+        [Parameter()]
+        [System.UInt32]
+        $NoRefreshInterval = 168
+    )
+
+    Write-Verbose "Testing the DNS zone aging for $Name ..."
+
+    $currentConfiguration = Get-TargetResource -Name $Name -AgingEnabled $AgingEnabled
+
+    return $currentConfiguration.AgingEnabled -eq $AgingEnabled -and
+           $currentConfiguration.RefreshInterval -eq $RefreshInterval -and
+           $currentConfiguration.NoRefreshInterval -eq $NoRefreshInterval
+}

--- a/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.psm1
+++ b/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.psm1
@@ -24,7 +24,7 @@ function Get-TargetResource
         $AgingEnabled
     )
 
-    Write-Verbose "Getting the DNS zone aging for $Name ..."
+    Write-Verbose -Message "Getting the DNS zone aging for $Name ..."
 
     # Get the current zone aging from the local DNS server
     $zoneAging = Get-DnsServerZoneAging -Name $Name
@@ -80,7 +80,7 @@ function Set-TargetResource
     # Enable or disable zone aging
     if ($currentConfiguration.AgingEnabled -ne $AgingEnabled)
     {
-        Write-Verbose "$(if ($AgingEnabled) { 'Enable' } else { 'Disable' }) DNS zone aging on $Name ..."
+        Write-Verbose -Message "$() DNS zone aging on $Name ..."
         
         Set-DnsServerZoneAging -Name $Name -Aging $AgingEnabled -WarningAction 'SilentlyContinue'
     }
@@ -88,7 +88,7 @@ function Set-TargetResource
     # Update the refresh interval
     if ($currentConfiguration.RefreshInterval -ne $RefreshInterval)
     {
-        Write-Verbose "Set DNS zone refresh interval to $RefreshInterval hours ..."
+        Write-Verbose -Message "Set DNS zone refresh interval to $RefreshInterval hours ..."
 
         $refreshIntervalTimespan = [System.TimeSpan]::FromHours($RefreshInterval)
         Set-DnsServerZoneAging -Name $Name -RefreshInterval $refreshIntervalTimespan -WarningAction 'SilentlyContinue'
@@ -97,7 +97,7 @@ function Set-TargetResource
     # Update the no refresh interval
     if ($currentConfiguration.NoRefreshInterval -ne $NoRefreshInterval)
     {
-        Write-Verbose "Set DNS zone no refresh interval to $NoRefreshInterval hours ..."
+        Write-Verbose -Message "Set DNS zone no refresh interval to $NoRefreshInterval hours ..."
 
         $noRefreshIntervalTimespan = [System.TimeSpan]::FromHours($NoRefreshInterval)
         Set-DnsServerZoneAging -Name $Name -NoRefreshInterval $noRefreshIntervalTimespan -WarningAction 'SilentlyContinue'
@@ -144,7 +144,7 @@ function Test-TargetResource
         $NoRefreshInterval = 168
     )
 
-    Write-Verbose "Testing the DNS zone aging for $Name ..."
+    Write-Verbose -Message "Testing the DNS zone aging for $Name ..."
 
     $currentConfiguration = Get-TargetResource -Name $Name -AgingEnabled $AgingEnabled
 

--- a/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.psm1
+++ b/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.psm1
@@ -4,7 +4,7 @@
         Get the DNS zone aging settings.
 
     .PARAMETER Name
-        Name of the DNS zone.
+        Name of the DNS forward or reverse loookup zone.
 
     .PARAMETER AgingEnabled
         Option to enable scavenge stale resource records on the zone.
@@ -42,7 +42,7 @@ function Get-TargetResource
         Set the DNS zone aging settings.
 
     .PARAMETER Name
-        Name of the DNS zone.
+        Name of the DNS forward or reverse loookup zone.
 
     .PARAMETER AgingEnabled
         Option to enable scavenge stale resource records on the zone.
@@ -128,7 +128,7 @@ function Set-TargetResource
         Test the DNS zone aging settings.
 
     .PARAMETER Name
-        Name of the DNS zone.
+        Name of the DNS forward or reverse loookup zone.
 
     .PARAMETER AgingEnabled
         Option to enable scavenge stale resource records on the zone.

--- a/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.psm1
+++ b/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.psm1
@@ -6,7 +6,7 @@
     .PARAMETER Name
         Name of the DNS forward or reverse loookup zone.
 
-    .PARAMETER AgingEnabled
+    .PARAMETER Enabled
         Option to enable scavenge stale resource records on the zone.
 #>
 function Get-TargetResource
@@ -21,7 +21,7 @@ function Get-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.Boolean]
-        $AgingEnabled
+        $Enabled
     )
 
     Write-Verbose -Message "Getting the DNS zone aging for $Name."
@@ -31,7 +31,7 @@ function Get-TargetResource
 
     return @{
         Name              = $Name
-        AgingEnabled      = $zoneAging.AgingEnabled
+        Enabled           = $zoneAging.AgingEnabled
         RefreshInterval   = $zoneAging.RefreshInterval.TotalHours
         NoRefreshInterval = $zoneAging.NoRefreshInterval.TotalHours
     }
@@ -44,7 +44,7 @@ function Get-TargetResource
     .PARAMETER Name
         Name of the DNS forward or reverse loookup zone.
 
-    .PARAMETER AgingEnabled
+    .PARAMETER Enabled
         Option to enable scavenge stale resource records on the zone.
 
     .PARAMETER RefreshInterval
@@ -64,7 +64,7 @@ function Set-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.Boolean]
-        $AgingEnabled,
+        $Enabled,
 
         [Parameter()]
         [System.UInt32]
@@ -75,12 +75,12 @@ function Set-TargetResource
         $NoRefreshInterval = 168
     )
 
-    $currentConfiguration = Get-TargetResource -Name $Name -AgingEnabled $AgingEnabled
+    $currentConfiguration = Get-TargetResource -Name $Name -Enabled $Enabled
 
     # Enable or disable zone aging
-    if ($currentConfiguration.AgingEnabled -ne $AgingEnabled)
+    if ($currentConfiguration.Enabled -ne $Enabled)
     {
-        if ($AgingEnabled)
+        if ($Enabled)
         {
             Write-Verbose -Message "Enable DNS zone aging on $Name."
         }
@@ -89,7 +89,7 @@ function Set-TargetResource
             Write-Verbose -Message "Disable DNS zone aging on $Name."
         }
 
-        Set-DnsServerZoneAging -Name $Name -Aging $AgingEnabled -WarningAction 'SilentlyContinue'
+        Set-DnsServerZoneAging -Name $Name -Aging $Enabled -WarningAction 'SilentlyContinue'
     }
 
     # Update the refresh interval
@@ -136,7 +136,7 @@ function Set-TargetResource
     .PARAMETER Name
         Name of the DNS forward or reverse loookup zone.
 
-    .PARAMETER AgingEnabled
+    .PARAMETER Enabled
         Option to enable scavenge stale resource records on the zone.
 
     .PARAMETER RefreshInterval
@@ -158,7 +158,7 @@ function Test-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.Boolean]
-        $AgingEnabled,
+        $Enabled,
 
         [Parameter()]
         [System.UInt32]
@@ -171,9 +171,9 @@ function Test-TargetResource
 
     Write-Verbose -Message "Testing the DNS zone aging for $Name."
 
-    $currentConfiguration = Get-TargetResource -Name $Name -AgingEnabled $AgingEnabled
+    $currentConfiguration = Get-TargetResource -Name $Name -Enabled $Enabled
 
-    $isDesiredState = $currentConfiguration.AgingEnabled -eq $AgingEnabled
+    $isDesiredState = $currentConfiguration.Enabled -eq $Enabled
 
     if ($PSBoundParameters.ContainsKey('RefreshInterval'))
     {

--- a/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.schema.mof
+++ b/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.schema.mof
@@ -1,0 +1,8 @@
+[ClassVersion("1.0.0.0"), FriendlyName("xDnsServerZoneAging")]
+class MSFT_xDnsServerZoneAging : OMI_BaseResource
+{
+    [Key, Description("Name of the DNS zone.")] String Name;
+    [Required, Description("Option to enable scavenge stale resource records on the zone.")] Boolean AgingEnabled;
+    [Write, Description("Refresh interval for record scavencing in hours. Default value is 7 days.")] UInt32 RefreshInterval;
+    [Write, Description("No-refresh interval for record scavencing in hours. Default value is 7 days.")] UInt32 NoRefreshInterval;
+};

--- a/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.schema.mof
+++ b/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.schema.mof
@@ -2,7 +2,7 @@
 class MSFT_xDnsServerZoneAging : OMI_BaseResource
 {
     [Key, Description("Name of the DNS forward or reverse loookup zone.")] String Name;
-    [Required, Description("Option to enable scavenge stale resource records on the zone.")] Boolean AgingEnabled;
+    [Required, Description("Option to enable scavenge stale resource records on the zone.")] Boolean Enabled;
     [Write, Description("Refresh interval for record scavencing in hours. Default value is 7 days.")] UInt32 RefreshInterval;
     [Write, Description("No-refresh interval for record scavencing in hours. Default value is 7 days.")] UInt32 NoRefreshInterval;
 };

--- a/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.schema.mof
+++ b/DSCResources/MSFT_xDnsServerZoneAging/MSFT_xDnsServerZoneAging.schema.mof
@@ -1,7 +1,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xDnsServerZoneAging")]
 class MSFT_xDnsServerZoneAging : OMI_BaseResource
 {
-    [Key, Description("Name of the DNS zone.")] String Name;
+    [Key, Description("Name of the DNS forward or reverse loookup zone.")] String Name;
     [Required, Description("Option to enable scavenge stale resource records on the zone.")] Boolean AgingEnabled;
     [Write, Description("Refresh interval for record scavencing in hours. Default value is 7 days.")] UInt32 RefreshInterval;
     [Write, Description("No-refresh interval for record scavencing in hours. Default value is 7 days.")] UInt32 NoRefreshInterval;

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ### xDnsServerZoneAging
 
 * **Name**: Name of the DNS forward or reverse loookup zone.
-* **AgingEnabled**: Option to enable scavenge stale resource records on the zone.
+* **Enabled**: Option to enable scavenge stale resource records on the zone.
 * **RefreshInterval**: Refresh interval for record scavencing in hours. Default value is 7 days.
 * **NoRefreshInterval**: No-refresh interval for record scavencing in hours. Default value is 7 days.
 
@@ -469,7 +469,7 @@ configuration Sample_DnsZoneAging
         xDnsServerZoneAging DnsServerZoneAging
         {
             Name              = 'contoso.com'
-            AgingEnabled      = $true
+            Enabled           = $true
             RefreshInterval   = 120   # 5 days
             NoRefreshInterval = 240   # 10 days
         }
@@ -491,7 +491,7 @@ configuration Sample_DnsReverseZoneAging
         xDnsServerZoneAging DnsServerReverseZoneAging
         {
             Name              = '168.192.in-addr-arpa'
-            AgingEnabled      = $true
+            Enabled           = $true
             RefreshInterval   = 168   # 7 days
             NoRefreshInterval = 168   # 7 days
         }

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **Ensure**: Whether the secondary zone should be present or removed
 * **Type**: Type of the DNS server zone
 
+### xDnsServerZoneAging
+
+* **Name**: Name of the DNS zone.
+* **AgingEnabled**: Option to enable scavenge stale resource records on the zone.
+* **RefreshInterval**: Refresh interval for record scavencing in hours. Default value is 7 days.
+* **NoRefreshInterval**: No-refresh interval for record scavencing in hours. Default value is 7 days.
+
 ### xDnsServerZoneTransfer
 
 * **Name**: Name of the DNS zone
@@ -136,6 +143,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ## Versions
 
 ### Unreleased
+
+* Added resource xDnsServerZoneAging
 
 ### 1.9.0.0
 * Added resource xDnsServerSetting
@@ -446,4 +455,26 @@ configuration Sample_DnsSettings
 }
 
 Sample_DnsSettings
+```
+
+### Enable DNS Zone Aging
+
+```powershell
+configuration Sample_DnsZoneAging
+{
+    Import-DscResource -ModuleName xDnsServer
+
+    node localhost
+    {
+        xDnsServerZoneAging DnsServerZoneAging
+        {
+            Name              = 'contoso.com'
+            AgingEnabled      = $true
+            RefreshInterval   = 120   # 5 days
+            NoRefreshInterval = 240   # 10 days
+        }
+    }
+}
+
+Sample_DnsZoneAging
 ```

--- a/README.md
+++ b/README.md
@@ -478,3 +478,25 @@ configuration Sample_DnsZoneAging
 
 Sample_DnsZoneAging
 ```
+
+### Enable DNS Reverse Zone Aging
+
+```powershell
+configuration Sample_DnsReverseZoneAging
+{
+    Import-DscResource -ModuleName xDnsServer
+
+    node localhost
+    {
+        xDnsServerZoneAging DnsServerReverseZoneAging
+        {
+            Name              = '168.192.in-addr-arpa'
+            AgingEnabled      = $true
+            RefreshInterval   = 168   # 7 days
+            NoRefreshInterval = 168   # 7 days
+        }
+    }
+}
+
+Sample_DnsReverseZoneAging
+```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **IsSingleInstance**: Specifies the resource is a single instance, the value must be 'Yes'
 * **IPAddresses**: IP addresses of the forwarders
 
-#### xDnsServerADZone
+### xDnsServerADZone
 
 * **Name**: Name of the AD DNS zone
 * **Ensure**: Whether the AD zone should be present or removed

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### xDnsServerZoneAging
 
-* **Name**: Name of the DNS zone.
+* **Name**: Name of the DNS forward or reverse loookup zone.
 * **AgingEnabled**: Option to enable scavenge stale resource records on the zone.
 * **RefreshInterval**: Refresh interval for record scavencing in hours. Default value is 7 days.
 * **NoRefreshInterval**: No-refresh interval for record scavencing in hours. Default value is 7 days.

--- a/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
@@ -110,7 +110,7 @@ try
 
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
 
-                It 'Returns a "System.Collections.Hashtable" object type' {
+                It 'Should return a "System.Collections.Hashtable" object type' {
 
                     # Act
                     $targetResource = Get-TargetResource @getParameterDisable
@@ -119,7 +119,7 @@ try
                     $targetResource -is [System.Collections.Hashtable] | Should Be $true
                 }
 
-                It "Returns valid values when aging is enabled" {
+                It "Should return valid values when aging is enabled" {
 
                     # Act
                     $targetResource = Get-TargetResource @getParameterEnable
@@ -136,7 +136,7 @@ try
 
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingDisabled }
 
-                It "Returns valid values when aging is not enabled" {
+                It "Should return valid values when aging is not enabled" {
 
                     # Act
                     $targetResource = Get-TargetResource @getParameterDisable
@@ -158,7 +158,7 @@ try
 
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
 
-                It 'Returns a "System.Boolean" object type' {
+                It 'Should return a "System.Boolean" object type' {
 
                     # Act
                     $targetResource = Test-TargetResource @testParameterDisable
@@ -167,7 +167,7 @@ try
                     $targetResource -is [System.Boolean] | Should Be $true
                 }
 
-                It 'Passes when everything matches (enabled)' {
+                It 'Should pass when everything matches (enabled)' {
 
                     # Act
                     $targetResource = Test-TargetResource @testParameterEnable
@@ -176,7 +176,7 @@ try
                     $targetResource | Should Be $true
                 }
 
-                It 'Fails when everything matches (enabled)' {
+                It 'Should fail when everything matches (enabled)' {
 
                     # Act
                     $targetResource = Test-TargetResource @testParameterDisable
@@ -190,7 +190,7 @@ try
 
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingDisabled }
 
-                It 'Passes when everything matches (disabled)' {
+                It 'Should pass when everything matches (disabled)' {
 
                     # Act
                     $targetResource = Test-TargetResource @testParameterDisable
@@ -199,7 +199,7 @@ try
                     $targetResource | Should Be $true
                 }
 
-                It 'Fails when everything matches (disabled)' {
+                It 'Should fail when everything matches (disabled)' {
 
                     # Act
                     $targetResource = Test-TargetResource @testParameterEnable

--- a/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
@@ -1,0 +1,288 @@
+﻿$Global:DSCModuleName      = 'xDnsServer'
+$Global:DSCResourceName    = 'MSFT_xDnsServerZoneAging'
+
+#region HEADER
+[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
+if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+else
+{
+    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
+}
+Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $Global:DSCModuleName `
+    -DSCResourceName $Global:DSCResourceName `
+    -TestType Unit 
+#endregion
+
+# Begin Testing
+try
+{
+    #region Pester Tests
+    InModuleScope $Global:DSCResourceName {
+
+        #region Pester Test Initialization
+        $getParameterEnable = @{
+            Name              = 'contoso.com'
+            AgingEnabled      = $true
+        }
+        $getParameterDisable = @{
+            Name              = 'contoso.com'
+            AgingEnabled      = $false
+        }
+        $testParameterEnable = @{
+            Name              = 'contoso.com'
+            AgingEnabled      = $true
+            RefreshInterval   = 168
+            NoRefreshInterval = 168
+        }
+        $testParameterDisable = @{
+            Name              = 'contoso.com'
+            AgingEnabled      = $false
+            RefreshInterval   = 168
+            NoRefreshInterval = 168
+        }
+        $setParameterEnable = @{
+            Name              = 'contoso.com'
+            AgingEnabled      = $true
+        }
+        $setParameterDisable = @{
+            Name              = 'contoso.com'
+            AgingEnabled      = $false
+        }
+        $setParameterRefreshInterval = @{
+            Name              = 'contoso.com'
+            AgingEnabled      = $true
+            RefreshInterval   = 24
+        }
+        $setParameterNoRefreshInterval = @{
+            Name              = 'contoso.com'
+            AgingEnabled      = $true
+            NoRefreshInterval = 36
+        }
+        $setFilterEnable = {
+            $Name -eq 'contoso.com' -and
+            $Aging -eq $true
+        }
+        $setFilterDisable = {
+            $Name -eq 'contoso.com' -and
+            $Aging -eq $false
+        }
+        $setFilterRefreshInterval = {
+            $Name -eq 'contoso.com' -and
+            $RefreshInterval -eq ([System.TimeSpan]::FromHours(24))
+        }
+        $setFilterNoRefreshInterval = {
+            $Name -eq 'contoso.com' -and
+            $NoRefreshInterval -eq ([System.TimeSpan]::FromHours(36))
+        }
+        $fakeDnsServerZoneAgingEnabled = @{
+            ZoneName          = 'contoso.com'
+            AgingEnabled      = $true
+            RefreshInterval   = [System.TimeSpan]::FromHours(168)
+            NoRefreshInterval = [System.TimeSpan]::FromHours(168)
+        }
+        $fakeDnsServerZoneAgingDisabled = @{
+            ZoneName          = 'contoso.com'
+            AgingEnabled      = $false
+            RefreshInterval   = [System.TimeSpan]::FromHours(168)
+            NoRefreshInterval = [System.TimeSpan]::FromHours(168)
+        }
+        #endregion
+
+        #region Function Get-TargetResource
+        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+            It 'Returns a "System.Collections.Hashtable" object type' {
+
+                # Arrange
+                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
+
+                # Act
+                $targetResource = Get-TargetResource @getParameterDisable
+
+                # Assert
+                $targetResource -is [System.Collections.Hashtable] | Should Be $true
+            }
+
+            It "Returns valid values when aging is enabled" {
+
+                # Arrange
+                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
+
+                # Act
+                $targetResource = Get-TargetResource @getParameterEnable
+
+                # Assert
+                $targetResource.Name              | Should Be $testParameterEnable.Name
+                $targetResource.AgingEnabled      | Should Be $testParameterEnable.AgingEnabled
+                $targetResource.RefreshInterval   | Should Be $testParameterEnable.RefreshInterval
+                $targetResource.NoRefreshInterval | Should Be $testParameterEnable.NoRefreshInterval
+            }
+
+            It "Returns valid values when aging is not enabled" {
+
+                # Arrange
+                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingDisabled }
+
+                # Act
+                $targetResource = Get-TargetResource @getParameterDisable
+
+                # Assert
+                $targetResource.Name              | Should Be $testParameterDisable.Name
+                $targetResource.AgingEnabled      | Should Be $testParameterDisable.AgingEnabled
+                $targetResource.RefreshInterval   | Should Be $testParameterDisable.RefreshInterval
+                $targetResource.NoRefreshInterval | Should Be $testParameterDisable.NoRefreshInterval
+            }
+        }
+        #endregion
+
+        #region Function Test-TargetResource
+        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+            It 'Returns a "System.Boolean" object type' {
+
+                # Arrange
+                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
+
+                # Act
+                $targetResource = Test-TargetResource @testParameterDisable
+
+                # Assert
+                $targetResource -is [System.Boolean] | Should Be $true
+            }
+
+            It 'Passes when everything matches (enabled)' {
+
+                # Arrange
+                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
+
+                # Act
+                $targetResource = Test-TargetResource @testParameterEnable
+
+                # Assert
+                $targetResource | Should Be $true
+            }
+
+            It 'Passes when everything matches (disabled)' {
+
+                # Arrange
+                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingDisabled }
+
+                # Act
+                $targetResource = Test-TargetResource @testParameterDisable
+
+                # Assert
+                $targetResource | Should Be $true
+            }
+
+            It 'Fails when everything matches (enabled)' {
+
+                # Arrange
+                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
+
+                # Act
+                $targetResource = Test-TargetResource @testParameterDisable
+
+                # Assert
+                $targetResource | Should Be $false
+            }
+
+            It 'Fails when everything matches (disabled)' {
+
+                # Arrange
+                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingDisabled }
+
+                # Act
+                $targetResource = Test-TargetResource @testParameterEnable
+
+                # Assert
+                $targetResource | Should Be $false
+            }
+        }
+        #endregion
+
+        #region Function Set-TargetResource
+        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
+
+            It "Enable the DNS zone aging" {
+
+                # Arrange
+                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingDisabled }
+                Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterEnable -Verifiable
+
+                # Act
+                Set-TargetResource @setParameterEnable
+
+                # Assert
+                Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterEnable -Times 1 -Exactly -Scope It
+            }
+
+            It "Disable the DNS zone aging" {
+
+                # Arrange
+                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
+                Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterDisable -Verifiable
+
+                # Act
+                Set-TargetResource @setParameterDisable
+
+                # Assert
+                Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterDisable -Times 1 -Exactly -Scope It
+            }
+
+            It "Set the DNS zone refresh interval" {
+
+                # Arrange
+                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
+                Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterRefreshInterval -Verifiable
+
+                # Act
+                Set-TargetResource @setParameterRefreshInterval
+
+                # Assert
+                Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterRefreshInterval -Times 1 -Exactly -Scope It
+            }
+
+            It "Set the DNS zone no refresh interval" {
+
+                # Arrange
+                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
+                Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterNoRefreshInterval -Verifiable
+
+                # Act
+                Set-TargetResource @setParameterNoRefreshInterval
+
+                # Assert
+                Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterNoRefreshInterval -Times 1 -Exactly -Scope It
+            }
+
+
+            # It "Calls Invoke-CimMethod called once when Zone Transfer Type does not match" {
+            #     Mock -CommandName Get-DnsServerZoneAging -MockWith {return $fakeCimInstanceNamed}
+            #     Set-TargetResource @testParamsAny
+            #     Assert-MockCalled -CommandName Invoke-CimMethod -Times 1 -Exactly -Scope It
+            # }
+
+            # It "Calls Invoke-CimMethod not called when Zone Transfer Secondaries matches" {
+            #     Mock -CommandName Get-DnsServerZoneAging -MockWith {return $fakeCimInstanceSpecific}
+            #     Set-TargetResource @testParamsSpecific
+            #     Assert-MockCalled -CommandName Invoke-CimMethod -Times 0 -Exactly -Scope It
+            # }
+
+            # It "Calls Invoke-CimMethod called once when Zone Transfer Secondaries does not match" {
+            #     Mock -CommandName Get-DnsServerZoneAging -MockWith {return $fakeCimInstanceSpecific}
+            #     Set-TargetResource @testParamsSpecificDifferent
+            #     Assert-MockCalled -CommandName Invoke-CimMethod -Times 1 -Exactly -Scope It
+            # }
+        }
+    } #end InModuleScope
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}

--- a/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
@@ -130,7 +130,7 @@ try
 
                     # Assert
                     $targetResource.Name              | Should Be $testParameterEnable.Name
-                    $targetResource.AgingEnabled      | Should Be $testParameterEnable.AgingEnabled
+                    $targetResource.Enabled           | Should Be $testParameterEnable.Enabled
                     $targetResource.RefreshInterval   | Should Be $testParameterEnable.RefreshInterval
                     $targetResource.NoRefreshInterval | Should Be $testParameterEnable.NoRefreshInterval
                 }
@@ -147,7 +147,7 @@ try
 
                     # Assert
                     $targetResource.Name              | Should Be $testParameterDisable.Name
-                    $targetResource.AgingEnabled      | Should Be $testParameterDisable.AgingEnabled
+                    $targetResource.Enabled           | Should Be $testParameterDisable.Enabled
                     $targetResource.RefreshInterval   | Should Be $testParameterDisable.RefreshInterval
                     $targetResource.NoRefreshInterval | Should Be $testParameterDisable.NoRefreshInterval
                 }

--- a/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
@@ -1,93 +1,106 @@
-﻿$Global:DSCModuleName      = 'xDnsServer'
-$Global:DSCResourceName    = 'MSFT_xDnsServerZoneAging'
+﻿$Global:DSCModuleName   = 'xDnsServer'
+$Global:DSCResourceName = 'MSFT_xDnsServerZoneAging'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+
+# Unit Test Template Version: 1.2.1
+$script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
+
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `
     -DSCResourceName $Global:DSCResourceName `
-    -TestType Unit 
-#endregion
+    -TestType Unit
+
+#endregion HEADER
+
+function Invoke-TestSetup {
+    # TODO: Optional init code goes here...
+}
+
+function Invoke-TestCleanup {
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+
+    # TODO: Other Optional Cleanup Code Goes Here...
+}
 
 # Begin Testing
 try
 {
-    #region Pester Tests
+    Invoke-TestSetup
+
     InModuleScope $Global:DSCResourceName {
 
         #region Pester Test Initialization
+        $zoneName = 'contoso.com'
         $getParameterEnable = @{
-            Name              = 'contoso.com'
-            AgingEnabled      = $true
+            Name              = $zoneName
+            Enabled           = $true
         }
         $getParameterDisable = @{
-            Name              = 'contoso.com'
-            AgingEnabled      = $false
+            Name              = $zoneName
+            Enabled           = $false
         }
         $testParameterEnable = @{
-            Name              = 'contoso.com'
-            AgingEnabled      = $true
+            Name              = $zoneName
+            Enabled           = $true
             RefreshInterval   = 168
             NoRefreshInterval = 168
         }
         $testParameterDisable = @{
-            Name              = 'contoso.com'
-            AgingEnabled      = $false
+            Name              = $zoneName
+            Enabled           = $false
             RefreshInterval   = 168
             NoRefreshInterval = 168
         }
         $setParameterEnable = @{
-            Name              = 'contoso.com'
-            AgingEnabled      = $true
+            Name              = $zoneName
+            Enabled           = $true
         }
         $setParameterDisable = @{
-            Name              = 'contoso.com'
-            AgingEnabled      = $false
+            Name              = $zoneName
+            Enabled           = $false
         }
         $setParameterRefreshInterval = @{
-            Name              = 'contoso.com'
-            AgingEnabled      = $true
+            Name              = $zoneName
+            Enabled           = $true
             RefreshInterval   = 24
         }
         $setParameterNoRefreshInterval = @{
-            Name              = 'contoso.com'
-            AgingEnabled      = $true
+            Name              = $zoneName
+            Enabled           = $true
             NoRefreshInterval = 36
         }
         $setFilterEnable = {
-            $Name -eq 'contoso.com' -and
+            $Name -eq $zoneName -and
             $Aging -eq $true
         }
         $setFilterDisable = {
-            $Name -eq 'contoso.com' -and
+            $Name -eq $zoneName -and
             $Aging -eq $false
         }
         $setFilterRefreshInterval = {
-            $Name -eq 'contoso.com' -and
+            $Name -eq $zoneName -and
             $RefreshInterval -eq ([System.TimeSpan]::FromHours(24))
         }
         $setFilterNoRefreshInterval = {
-            $Name -eq 'contoso.com' -and
+            $Name -eq $zoneName -and
             $NoRefreshInterval -eq ([System.TimeSpan]::FromHours(36))
         }
         $fakeDnsServerZoneAgingEnabled = @{
-            ZoneName          = 'contoso.com'
+            ZoneName          = $zoneName
             AgingEnabled      = $true
             RefreshInterval   = [System.TimeSpan]::FromHours(168)
             NoRefreshInterval = [System.TimeSpan]::FromHours(168)
         }
         $fakeDnsServerZoneAgingDisabled = @{
-            ZoneName          = 'contoso.com'
+            ZoneName          = $zoneName
             AgingEnabled      = $false
             RefreshInterval   = [System.TimeSpan]::FromHours(168)
             NoRefreshInterval = [System.TimeSpan]::FromHours(168)
@@ -96,110 +109,108 @@ try
 
         #region Function Get-TargetResource
         Describe "$($Global:DSCResourceName)\Get-TargetResource" {
-            It 'Returns a "System.Collections.Hashtable" object type' {
 
-                # Arrange
+            Context "The zone aging on $zoneName is enabled" {
+
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
 
-                # Act
-                $targetResource = Get-TargetResource @getParameterDisable
+                It 'Returns a "System.Collections.Hashtable" object type' {
 
-                # Assert
-                $targetResource -is [System.Collections.Hashtable] | Should Be $true
+                    # Act
+                    $targetResource = Get-TargetResource @getParameterDisable
+
+                    # Assert
+                    $targetResource -is [System.Collections.Hashtable] | Should Be $true
+                }
+
+                It "Returns valid values when aging is enabled" {
+
+                    # Act
+                    $targetResource = Get-TargetResource @getParameterEnable
+
+                    # Assert
+                    $targetResource.Name              | Should Be $testParameterEnable.Name
+                    $targetResource.AgingEnabled      | Should Be $testParameterEnable.AgingEnabled
+                    $targetResource.RefreshInterval   | Should Be $testParameterEnable.RefreshInterval
+                    $targetResource.NoRefreshInterval | Should Be $testParameterEnable.NoRefreshInterval
+                }
             }
 
-            It "Returns valid values when aging is enabled" {
+            Context "The zone aging on $zoneName is disabled" {
 
-                # Arrange
-                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
-
-                # Act
-                $targetResource = Get-TargetResource @getParameterEnable
-
-                # Assert
-                $targetResource.Name              | Should Be $testParameterEnable.Name
-                $targetResource.AgingEnabled      | Should Be $testParameterEnable.AgingEnabled
-                $targetResource.RefreshInterval   | Should Be $testParameterEnable.RefreshInterval
-                $targetResource.NoRefreshInterval | Should Be $testParameterEnable.NoRefreshInterval
-            }
-
-            It "Returns valid values when aging is not enabled" {
-
-                # Arrange
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingDisabled }
 
-                # Act
-                $targetResource = Get-TargetResource @getParameterDisable
+                It "Returns valid values when aging is not enabled" {
 
-                # Assert
-                $targetResource.Name              | Should Be $testParameterDisable.Name
-                $targetResource.AgingEnabled      | Should Be $testParameterDisable.AgingEnabled
-                $targetResource.RefreshInterval   | Should Be $testParameterDisable.RefreshInterval
-                $targetResource.NoRefreshInterval | Should Be $testParameterDisable.NoRefreshInterval
+                    # Act
+                    $targetResource = Get-TargetResource @getParameterDisable
+
+                    # Assert
+                    $targetResource.Name              | Should Be $testParameterDisable.Name
+                    $targetResource.AgingEnabled      | Should Be $testParameterDisable.AgingEnabled
+                    $targetResource.RefreshInterval   | Should Be $testParameterDisable.RefreshInterval
+                    $targetResource.NoRefreshInterval | Should Be $testParameterDisable.NoRefreshInterval
+                }
             }
         }
         #endregion
 
         #region Function Test-TargetResource
         Describe "$($Global:DSCResourceName)\Test-TargetResource" {
-            It 'Returns a "System.Boolean" object type' {
 
-                # Arrange
+            Context "The zone aging on $zoneName is enabled" {
+
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
 
-                # Act
-                $targetResource = Test-TargetResource @testParameterDisable
+                It 'Returns a "System.Boolean" object type' {
 
-                # Assert
-                $targetResource -is [System.Boolean] | Should Be $true
+                    # Act
+                    $targetResource = Test-TargetResource @testParameterDisable
+
+                    # Assert
+                    $targetResource -is [System.Boolean] | Should Be $true
+                }
+
+                It 'Passes when everything matches (enabled)' {
+
+                    # Act
+                    $targetResource = Test-TargetResource @testParameterEnable
+
+                    # Assert
+                    $targetResource | Should Be $true
+                }
+
+                It 'Fails when everything matches (enabled)' {
+
+                    # Act
+                    $targetResource = Test-TargetResource @testParameterDisable
+
+                    # Assert
+                    $targetResource | Should Be $false
+                }
             }
 
-            It 'Passes when everything matches (enabled)' {
+            Context "The zone aging on $zoneName is disabled" {
 
-                # Arrange
-                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
-
-                # Act
-                $targetResource = Test-TargetResource @testParameterEnable
-
-                # Assert
-                $targetResource | Should Be $true
-            }
-
-            It 'Passes when everything matches (disabled)' {
-
-                # Arrange
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingDisabled }
 
-                # Act
-                $targetResource = Test-TargetResource @testParameterDisable
+                It 'Passes when everything matches (disabled)' {
 
-                # Assert
-                $targetResource | Should Be $true
-            }
+                    # Act
+                    $targetResource = Test-TargetResource @testParameterDisable
 
-            It 'Fails when everything matches (enabled)' {
+                    # Assert
+                    $targetResource | Should Be $true
+                }
 
-                # Arrange
-                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
+                It 'Fails when everything matches (disabled)' {
 
-                # Act
-                $targetResource = Test-TargetResource @testParameterDisable
+                    # Act
+                    $targetResource = Test-TargetResource @testParameterEnable
 
-                # Assert
-                $targetResource | Should Be $false
-            }
-
-            It 'Fails when everything matches (disabled)' {
-
-                # Arrange
-                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingDisabled }
-
-                # Act
-                $targetResource = Test-TargetResource @testParameterEnable
-
-                # Assert
-                $targetResource | Should Be $false
+                    # Assert
+                    $targetResource | Should Be $false
+                }
             }
         }
         #endregion
@@ -207,57 +218,64 @@ try
         #region Function Set-TargetResource
         Describe "$($Global:DSCResourceName)\Set-TargetResource" {
 
-            It "Enable the DNS zone aging" {
+            Context "The zone aging on $zoneName is enabled" {
 
-                # Arrange
+                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
+
+                It "Disable the DNS zone aging" {
+
+                    # Arrange
+                    Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterDisable -Verifiable
+
+                    # Act
+                    Set-TargetResource @setParameterDisable
+
+                    # Assert
+                    Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterDisable -Times 1 -Exactly -Scope It
+                }
+
+                It "Set the DNS zone refresh interval" {
+
+                    # Arrange
+                    Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterRefreshInterval -Verifiable
+
+                    # Act
+                    Set-TargetResource @setParameterRefreshInterval
+
+                    # Assert
+                    Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterRefreshInterval -Times 1 -Exactly -Scope It
+                }
+
+                It "Set the DNS zone no refresh interval" {
+
+                    # Arrange
+                    Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterNoRefreshInterval -Verifiable
+
+                    # Act
+                    Set-TargetResource @setParameterNoRefreshInterval
+
+                    # Assert
+                    Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterNoRefreshInterval -Times 1 -Exactly -Scope It
+                }
+            }
+
+            Context "The zone aging on $zoneName is disabled" {
+
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingDisabled }
-                Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterEnable -Verifiable
 
-                # Act
-                Set-TargetResource @setParameterEnable
+                It "Enable the DNS zone aging" {
 
-                # Assert
-                Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterEnable -Times 1 -Exactly -Scope It
+                    # Arrange
+                    Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterEnable -Verifiable
+
+                    # Act
+                    Set-TargetResource @setParameterEnable
+
+                    # Assert
+                    Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterEnable -Times 1 -Exactly -Scope It
+                }
             }
 
-            It "Disable the DNS zone aging" {
-
-                # Arrange
-                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
-                Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterDisable -Verifiable
-
-                # Act
-                Set-TargetResource @setParameterDisable
-
-                # Assert
-                Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterDisable -Times 1 -Exactly -Scope It
-            }
-
-            It "Set the DNS zone refresh interval" {
-
-                # Arrange
-                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
-                Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterRefreshInterval -Verifiable
-
-                # Act
-                Set-TargetResource @setParameterRefreshInterval
-
-                # Assert
-                Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterRefreshInterval -Times 1 -Exactly -Scope It
-            }
-
-            It "Set the DNS zone no refresh interval" {
-
-                # Arrange
-                Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
-                Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterNoRefreshInterval -Verifiable
-
-                # Act
-                Set-TargetResource @setParameterNoRefreshInterval
-
-                # Assert
-                Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterNoRefreshInterval -Times 1 -Exactly -Scope It
-            }
 
 
             # It "Calls Invoke-CimMethod called once when Zone Transfer Type does not match" {
@@ -278,11 +296,10 @@ try
             #     Assert-MockCalled -CommandName Invoke-CimMethod -Times 1 -Exactly -Scope It
             # }
         }
-    } #end InModuleScope
+        #endregion
+    }
 }
 finally
 {
-    #region FOOTER
-    Restore-TestEnvironment -TestEnvironment $TestEnvironment
-    #endregion
+    Invoke-TestCleanup
 }

--- a/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
@@ -1,4 +1,4 @@
-﻿$Global:DSCModuleName   = 'xDnsServer'
+$Global:DSCModuleName   = 'xDnsServer'
 $Global:DSCResourceName = 'MSFT_xDnsServerZoneAging'
 
 #region HEADER

--- a/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
@@ -20,14 +20,10 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion HEADER
 
-function Invoke-TestSetup {
-    # TODO: Optional init code goes here...
-}
+function Invoke-TestSetup { }
 
 function Invoke-TestCleanup {
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
-
-    # TODO: Other Optional Cleanup Code Goes Here...
 }
 
 # Begin Testing

--- a/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
@@ -111,16 +111,14 @@ try
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
 
                 It 'Should return a "System.Collections.Hashtable" object type' {
-
                     # Act
                     $targetResource = Get-TargetResource @getParameterDisable
 
                     # Assert
-                    $targetResource -is [System.Collections.Hashtable] | Should Be $true
+                    $targetResource | Should BeOfType [System.Collections.Hashtable]
                 }
 
-                It "Should return valid values when aging is enabled" {
-
+                It 'Should return valid values when aging is enabled' {
                     # Act
                     $targetResource = Get-TargetResource @getParameterEnable
 
@@ -136,8 +134,7 @@ try
 
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingDisabled }
 
-                It "Should return valid values when aging is not enabled" {
-
+                It 'Should return valid values when aging is not enabled' {
                     # Act
                     $targetResource = Get-TargetResource @getParameterDisable
 
@@ -159,16 +156,14 @@ try
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
 
                 It 'Should return a "System.Boolean" object type' {
-
                     # Act
                     $targetResource = Test-TargetResource @testParameterDisable
 
                     # Assert
-                    $targetResource -is [System.Boolean] | Should Be $true
+                    $targetResource | Should BeOfType [System.Boolean]
                 }
 
                 It 'Should pass when everything matches (enabled)' {
-
                     # Act
                     $targetResource = Test-TargetResource @testParameterEnable
 
@@ -177,7 +172,6 @@ try
                 }
 
                 It 'Should fail when everything matches (enabled)' {
-
                     # Act
                     $targetResource = Test-TargetResource @testParameterDisable
 
@@ -191,7 +185,6 @@ try
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingDisabled }
 
                 It 'Should pass when everything matches (disabled)' {
-
                     # Act
                     $targetResource = Test-TargetResource @testParameterDisable
 
@@ -200,7 +193,6 @@ try
                 }
 
                 It 'Should fail when everything matches (disabled)' {
-
                     # Act
                     $targetResource = Test-TargetResource @testParameterEnable
 
@@ -218,8 +210,7 @@ try
 
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
 
-                It "Disable the DNS zone aging" {
-
+                It 'Disable the DNS zone aging' {
                     # Arrange
                     Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterDisable -Verifiable
 
@@ -230,8 +221,7 @@ try
                     Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterDisable -Times 1 -Exactly -Scope It
                 }
 
-                It "Set the DNS zone refresh interval" {
-
+                It 'Set the DNS zone refresh interval' {
                     # Arrange
                     Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterRefreshInterval -Verifiable
 
@@ -242,8 +232,7 @@ try
                     Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterRefreshInterval -Times 1 -Exactly -Scope It
                 }
 
-                It "Set the DNS zone no refresh interval" {
-
+                It 'Set the DNS zone no refresh interval' {
                     # Arrange
                     Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterNoRefreshInterval -Verifiable
 
@@ -259,8 +248,7 @@ try
 
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingDisabled }
 
-                It "Enable the DNS zone aging" {
-
+                It 'Enable the DNS zone aging' {
                     # Arrange
                     Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterEnable -Verifiable
 
@@ -271,26 +259,6 @@ try
                     Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterEnable -Times 1 -Exactly -Scope It
                 }
             }
-
-
-
-            # It "Calls Invoke-CimMethod called once when Zone Transfer Type does not match" {
-            #     Mock -CommandName Get-DnsServerZoneAging -MockWith {return $fakeCimInstanceNamed}
-            #     Set-TargetResource @testParamsAny
-            #     Assert-MockCalled -CommandName Invoke-CimMethod -Times 1 -Exactly -Scope It
-            # }
-
-            # It "Calls Invoke-CimMethod not called when Zone Transfer Secondaries matches" {
-            #     Mock -CommandName Get-DnsServerZoneAging -MockWith {return $fakeCimInstanceSpecific}
-            #     Set-TargetResource @testParamsSpecific
-            #     Assert-MockCalled -CommandName Invoke-CimMethod -Times 0 -Exactly -Scope It
-            # }
-
-            # It "Calls Invoke-CimMethod called once when Zone Transfer Secondaries does not match" {
-            #     Mock -CommandName Get-DnsServerZoneAging -MockWith {return $fakeCimInstanceSpecific}
-            #     Set-TargetResource @testParamsSpecificDifferent
-            #     Assert-MockCalled -CommandName Invoke-CimMethod -Times 1 -Exactly -Scope It
-            # }
         }
         #endregion
     }

--- a/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerZoneAging.Tests.ps1
@@ -210,7 +210,7 @@ try
 
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingEnabled }
 
-                It 'Disable the DNS zone aging' {
+                It 'Should disable the DNS zone aging' {
                     # Arrange
                     Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterDisable -Verifiable
 
@@ -221,7 +221,7 @@ try
                     Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterDisable -Times 1 -Exactly -Scope It
                 }
 
-                It 'Set the DNS zone refresh interval' {
+                It 'Should set the DNS zone refresh interval' {
                     # Arrange
                     Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterRefreshInterval -Verifiable
 
@@ -232,7 +232,7 @@ try
                     Assert-MockCalled -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterRefreshInterval -Times 1 -Exactly -Scope It
                 }
 
-                It 'Set the DNS zone no refresh interval' {
+                It 'Should set the DNS zone no refresh interval' {
                     # Arrange
                     Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterNoRefreshInterval -Verifiable
 
@@ -248,7 +248,7 @@ try
 
                 Mock -CommandName Get-DnsServerZoneAging -MockWith { return $fakeDnsServerZoneAgingDisabled }
 
-                It 'Enable the DNS zone aging' {
+                It 'Should enable the DNS zone aging' {
                     # Arrange
                     Mock -CommandName Set-DnsServerZoneAging -ParameterFilter $setFilterEnable -Verifiable
 


### PR DESCRIPTION
I've created a new resource **xDnsServerZoneAging** to enable/disable the aging on DNS zones including the (no) refresh interval. I decided to put this settings in an extra resource instead of appending the same code to all existing resources which handle DNS zones: xDnsServerADZone, xDnsServerPrimaryZone, xDnsServerSecondaryZone. It's similar to the concept of the the xDnsServerZoneTransfer resource.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdnsserver/61)
<!-- Reviewable:end -->
