### PR TITLE
Fix xDnsServerADZone cim session bug

### DIFF
--- a/.MetaTestOptIn.json
+++ b/.MetaTestOptIn.json
@@ -1,0 +1,6 @@
+[
+    "Common Tests - Validate Markdown Files",
+    "Common Tests - Validate Module Files",
+    "Common Tests - Validate Script Files",
+    "Common Tests - Validate Example Files"
+]

--- a/DSCResources/Helper.psm1
+++ b/DSCResources/Helper.psm1
@@ -13,15 +13,15 @@ function New-TerminatingError
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String]
         $errorId,
         
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String]
         $errorMessage,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [System.Management.Automation.ErrorCategory]
         $errorCategory
     )
@@ -37,7 +37,7 @@ function Assert-Module
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [string]
         $Name
     )
@@ -56,7 +56,7 @@ function Remove-CommonParameter
     [cmdletbinding()]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [hashtable]
         $Hashtable
     )
@@ -77,17 +77,19 @@ function Test-DscParameterState
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory)] 
+        [Parameter(Mandatory = $true)]
         [hashtable]
         $CurrentValues,
 
-        [Parameter(Mandatory)] 
+        [Parameter(Mandatory = $true)]
         [object]
         $DesiredValues,
         
+        [Parameter()]
         [string[]]
         $ValuesToCheck,
         
+        [Parameter()]
         [switch]$TurnOffTypeChecking
     )
 
@@ -137,9 +139,8 @@ function Test-DscParameterState
         }
      
         if (-not $TurnOffTypeChecking)
-        {   
-            if (($desiredType.Name -ne 'Unknown' -and $currentType.Name -ne 'Unknown') -and
-            $desiredType.FullName -ne $currentType.FullName)
+        {
+            if (($desiredType.Name -ne 'Unknown' -and $currentType.Name -ne 'Unknown') -and $desiredType.FullName -ne $currentType.FullName)
             {
                 Write-Verbose -Message "NOTMATCH: Type mismatch for property '$key' Current state type is '$($currentType.Name)' and desired type is '$($desiredType.Name)'"
                 continue
@@ -253,10 +254,10 @@ function Test-DSCObjectHasProperty
     [OutputType([bool])]
     param
     (
-        [Parameter(Mandatory)] 
+        [Parameter(Mandatory = $true)]
         [object]$Object,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [string]$PropertyName
     )
 

--- a/DSCResources/MSFT_xDnsARecord/MSFT_xDnsARecord.psm1
+++ b/DSCResources/MSFT_xDnsARecord/MSFT_xDnsARecord.psm1
@@ -1,4 +1,4 @@
-﻿function Get-TargetResource
+function Get-TargetResource
 {
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
@@ -24,7 +24,8 @@
     Write-Warning -Message "DSC Resource xDnsARecord has been replaced by xDNSRecord, and will be removed in a future version"
     Write-Verbose "Looking up DNS record for $Name in $Zone"
     $record = Get-DnsServerResourceRecord -ZoneName $Zone -Name $Name -ErrorAction SilentlyContinue
-    if ($null -eq $record) {
+    if ($null -eq $record)
+    {
         return @{
             Name = $Name;
             Zone = $Zone;
@@ -65,7 +66,8 @@ function Set-TargetResource
         [System.String]
         $Ensure = 'Present'
     )
-    if ($Ensure -eq 'Present') {
+    if ($Ensure -eq 'Present')
+    {
         Write-Verbose "Creating for DNS $Target in $Zone"
         Add-DnsServerResourceRecordA -IPv4Address $Target -Name $Name -ZoneName $Zone
     }
@@ -102,8 +104,14 @@ function Test-TargetResource
 
     Write-Verbose "Testing for DNS $Name in $Zone"
     $result = @(Get-TargetResource @PSBoundParameters)
-    if ($Ensure -ne $result.Ensure) { return $false }
-    elseif ($Ensure -eq 'Present' -and ($result.Target -ne $Target)) { return $false }
+    if ($Ensure -ne $result.Ensure)
+    {
+        return $false 
+    }
+    elseif ($Ensure -eq 'Present' -and ($result.Target -ne $Target)) 
+    { 
+        return $false 
+    }
     return $true
 }
 

--- a/DSCResources/MSFT_xDnsServerADZone/MSFT_xDnsServerADZone.psm1
+++ b/DSCResources/MSFT_xDnsServerADZone/MSFT_xDnsServerADZone.psm1
@@ -5,13 +5,15 @@ data LocalizedData
 {
     # culture="en-US"
     ConvertFrom-StringData @'
-CheckingZoneMessage          = Checking DNS server zone with name '{0}' is '{1}'...
-AddingZoneMessage            = Adding DNS server zone '{0}' ...
-RemovingZoneMessage          = Removing DNS server zone '{0}' ...
+CheckingZoneMessage                   = Checking DNS server zone with name '{0}' is '{1}'...
+AddingZoneMessage                     = Adding DNS server zone '{0}' ...
+RemovingZoneMessage                   = Removing DNS server zone '{0}' ...
 
-CheckPropertyMessage         = Checking DNS server zone property '{0}' ...
-NotDesiredPropertyMessage    = DNS server zone property '{0}' is not correct. Expected '{1}', actual '{2}'
-SetPropertyMessage           = DNS server zone property '{0}' is set
+CheckPropertyMessage                  = Checking DNS server zone property '{0}' ...
+NotDesiredPropertyMessage             = DNS server zone property '{0}' is not correct. Expected '{1}', actual '{2}'
+SetPropertyMessage                    = DNS server zone property '{0}' is set
+
+CredentialRequiresComputerNameMessage = The Credentials Parameter can only be used when ComputerName is also specified.
 '@
 }
 
@@ -58,7 +60,7 @@ function Get-TargetResource
 
     if (!$PSBoundParameters.ContainsKey('ComputerName') -and $PSBoundParameters.ContainsKey('Credential'))
     {
-        throw "The Credentials Parameter can only be used when ComputerName is also specified"
+        throw $LocalizedData.CredentialRequiresComputerNameMessage
     }
 
     $getParams = @{

--- a/DSCResources/MSFT_xDnsServerForwarder/MSFT_xDnsServerForwarder.psm1
+++ b/DSCResources/MSFT_xDnsServerForwarder/MSFT_xDnsServerForwarder.psm1
@@ -3,7 +3,7 @@ function Get-TargetResource
     [OutputType([Hashtable])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Yes')]
         [string]
         $IsSingleInstance,
@@ -29,7 +29,7 @@ function Set-TargetResource
 {
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Yes')]
         [string]
         $IsSingleInstance,
@@ -56,7 +56,7 @@ function Test-TargetResource
     [OutputType([Bool])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Yes')]
         [string]
         $IsSingleInstance,

--- a/DSCResources/MSFT_xDnsServerPrimaryZone/MSFT_xDnsServerPrimaryZone.psm1
+++ b/DSCResources/MSFT_xDnsServerPrimaryZone/MSFT_xDnsServerPrimaryZone.psm1
@@ -21,7 +21,7 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
@@ -63,7 +63,7 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
@@ -128,7 +128,7 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
@@ -151,7 +151,8 @@ function Set-TargetResource
 
     Assert-Module -Name 'DNSServer';
 
-    if ($Ensure -eq 'Present') {
+    if ($Ensure -eq 'Present') 
+    {
         Write-Verbose ($LocalizedData.CheckingZoneMessage -f $Name, $Ensure);
         $dnsServerZone = Get-DnsServerZone -Name $Name -ErrorAction SilentlyContinue;
         if ($dnsServerZone)

--- a/DSCResources/MSFT_xDnsServerSecondaryZone/MSFT_xDnsServerSecondaryZone.psm1
+++ b/DSCResources/MSFT_xDnsServerSecondaryZone/MSFT_xDnsServerSecondaryZone.psm1
@@ -30,11 +30,11 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String]
         $Name,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String[]]
         $MasterServers
     )
@@ -70,11 +70,11 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String]
         $Name,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String[]]
         $MasterServers,
 
@@ -97,11 +97,11 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String]
         $Name,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String[]]
         $MasterServers,
 
@@ -130,11 +130,11 @@ function Test-ResourceProperties
     [OutputType([bool])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String]
         $Name,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String[]]
         $MasterServers,
 

--- a/DSCResources/MSFT_xDnsServerSetting/MSFT_xDnsServerSetting.psm1
+++ b/DSCResources/MSFT_xDnsServerSetting/MSFT_xDnsServerSetting.psm1
@@ -251,6 +251,7 @@ function Set-TargetResource
 
 function Test-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([bool])]
     param

--- a/DSCResources/MSFT_xDnsServerSetting/MSFT_xDnsServerSetting.psm1
+++ b/DSCResources/MSFT_xDnsServerSetting/MSFT_xDnsServerSetting.psm1
@@ -251,7 +251,6 @@ function Set-TargetResource
 
 function Test-TargetResource
 {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [CmdletBinding()]
     [OutputType([bool])]
     param
@@ -436,6 +435,8 @@ function Test-TargetResource
         [uint32]
         $XfrConnectTimeout
     )
+
+    Write-Verbose -Message 'Evaluating the DNS server settings.'
 
     $currentState = Get-TargetResource -Name $Name
 

--- a/DSCResources/MSFT_xDnsServerZoneTransfer/MSFT_xDnsServerZoneTransfer.psm1
+++ b/DSCResources/MSFT_xDnsServerZoneTransfer/MSFT_xDnsServerZoneTransfer.psm1
@@ -25,11 +25,11 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String]
         $Name,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet("None","Any","Named","Specific")]
         [String]
         $Type
@@ -59,11 +59,11 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String]
         $Name,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet("None","Any","Named","Specific")]
         [String]
         $Type,
@@ -90,11 +90,11 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String]
         $Name,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet("None","Any","Named","Specific")]
         [String]
         $Type,
@@ -124,11 +124,11 @@ function Test-ResourceProperties
     [OutputType([System.Boolean])]
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String]
         $Name,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet("None","Any","Named","Specific")]
         [String]
         $Type,

--- a/Misc/Generate_xDnsServerSetting.ps1
+++ b/Misc/Generate_xDnsServerSetting.ps1
@@ -1,4 +1,4 @@
-﻿$resourceProperties = @()
+$resourceProperties = @()
 $resourceProperties += New-xDscResourceProperty -Name Name -Type String -Attribute Key -Description "Key for the resource.  It doesn't matter what it is as long as it's unique within the configuration."
 $resourceProperties += New-xDscResourceProperty -Name AddressAnswerLimit -Type Uint32 -Attribute Write -Description "Maximum number of host records returned in response to an address request. Values between 5 and 28 are valid."
 $resourceProperties += New-xDscResourceProperty -Name AllowUpdate -Type Uint32 -Attribute Write -Description "Specifies whether the DNS Server accepts dynamic update requests."

--- a/Misc/MockObjects/DnsServerClass.xml
+++ b/Misc/MockObjects/DnsServerClass.xml
@@ -1,4 +1,4 @@
-﻿<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
   <Obj RefId="0">
     <TN RefId="0">
       <T>Microsoft.Management.Infrastructure.CimInstance#root/MicrosoftDNS/MicrosoftDNS_Server</T>

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **DirectoryPartitionName**: Name of the directory partition on which to store the zone.
   * Use this parameter when the ReplicationScope parameter has a value of Custom.
 * **ComputerName**: Specifies a DNS server.
-    * If you do not specify this parameter, the command runs on the local system.
-* **Credential**: Specifies the credential to use to create the AD zone.
-  * If you do not specify this parameter, the command runs as the local system.
+  * If you do not specify this parameter, the command runs on the local system.
+* **Credential**: Specifies the credential to use to create the AD zone on a remote computer.
+  * This parameter can only be used when you also are passing a value for the `ComputerName` parameter.
 
 ### xDnsServerPrimaryZone
 
@@ -137,7 +137,10 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleased
 
-* Fixed bug in xDnsServerADZone related to CimSessions preventing AD Integrated Zones from happening.
+* Changes to xDnsServerADZone
+  * Fixed bug introduced by [#49](https://github.com/PowerShell/xDnsServer/pull/49). Previously, CimSessions were always used 
+  regardless of connecting to a remote machine or the local machine.  Now CimSessions are only utilized when a computername or 
+  computername and credential are used. ([issue #53](https://github.com/PowerShell/xDnsServer/issues/53)).
 * Fixed all PSSA rule warnings.
 
 ### 1.9.0.0

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ### Unreleased
 
 ### 1.9.0.0
+
 * Added resource xDnsServerSetting
 * MSFT_xDnsRecord: Added DnsServer property
 

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ### Unreleased
 
 * Changes to xDnsServerADZone
-  * Fixed bug introduced by [#49](https://github.com/PowerShell/xDnsServer/pull/49). Previously, CimSessions were always used 
-  regardless of connecting to a remote machine or the local machine.  Now CimSessions are only utilized when a computername or 
+  * Fixed bug introduced by [#49](https://github.com/PowerShell/xDnsServer/pull/49). Previously, CimSessions were always used
+  regardless of connecting to a remote machine or the local machine.  Now CimSessions are only utilized when a computername or
   computername and credential are used. ([issue #53](https://github.com/PowerShell/xDnsServer/issues/53)).
 * Fixed all PSSA rule warnings.
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleased
 
+* Fixed bug in xDnsServerADZone related to CimSessions preventing AD Integrated Zones from happening.
+* Fixed all PSSA rule warnings.
+
 ### 1.9.0.0
 
 * Added resource xDnsServerSetting

--- a/Tests/Unit/MSFT_xDnsServerADZone.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerADZone.Tests.ps1
@@ -111,7 +111,7 @@ try
                         $withCredentialsParameter = $testParams + @{
                             Credential = $testCredential
                         }
-                        { Get-TargetResource @withCredentialsParameter -ReplicationScope $testReplicationScope } | Should -Throw 
+                        { Get-TargetResource @withCredentialsParameter -ReplicationScope $testReplicationScope } | Should -Throw $LocalizedData.CredentialRequiresComputerNameMessage
                     }
                 }
             }

--- a/Tests/Unit/MSFT_xDnsServerADZone.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerADZone.Tests.ps1
@@ -145,13 +145,22 @@ try
                         Mock -CommandName Remove-CimSession
                     }
 
-                    It 'Should throw an exception indicating a computername must also be passed' {
+                    It 'Should call New-CimSession' {
                         $withCredentialsAndComputerParameter = $testParams + @{
                             ComputerName = $testComputerName
                             Credential = $testCredential
                         }
                         Get-TargetResource @withCredentialsAndComputerParameter -ReplicationScope $testReplicationScope
                         Assert-MockCalled -CommandName New-CimSession -ParameterFilter { $computername -eq $withCredentialsAndComputerParameter.ComputerName -and $credential -eq $withCredentialsAndComputerParameter.Credential } -Scope It -Times 1 -Exactly
+                    }
+
+                    It 'Should call Remove-CimSession' {
+                        $withCredentialsAndComputerParameter = $testParams + @{
+                            ComputerName = $testComputerName
+                            Credential = $testCredential
+                        }
+                        Get-TargetResource @withCredentialsAndComputerParameter -ReplicationScope $testReplicationScope
+                        Assert-MockCalled -CommandName Remove-CimSession -Scope It -Times 1 -Exactly
                     }
                 }
             }
@@ -269,7 +278,7 @@ try
                 Assert-MockCalled -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $DirectoryPartitionName -eq 'IncorrectDirectoryPartitionName' } -Scope It
             }
 
-            Context 'When a computername is not passed' {
+            Context 'When a computer name is not passed' {
                 BeforeAll {
                     Mock -CommandName New-CimSession
                     Mock -CommandName Remove-CimSession
@@ -288,7 +297,7 @@ try
 
             Context 'When a computer name is passed' {
                 BeforeAll {
-                    Mock -CommandName New-CimSession
+                    Mock -CommandName New-CimSession -MockWith { New-MockObject -Type Microsoft.Management.Infrastructure.CimSession }
                     Mock -CommandName Remove-CimSession
                     Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
                 }
@@ -310,17 +319,26 @@ try
 
                 Context 'When credentials are passed' {
                     BeforeAll {
-                        Mock -CommandName New-CimSession
+                        Mock -CommandName New-CimSession -MockWith { New-MockObject -Type Microsoft.Management.Infrastructure.CimSession }
+                        Mock -CommandName Remove-CimSession
                         Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
                     }
 
-                    It 'Should throw an exception indicating a computername must also be passed' {
+                    It 'Should call New-CimSession' {
                         $withCredentialsAndComputerParameter = $testParams + @{
                             ComputerName = $testComputerName
                             Credential = $testCredential
                         }
                         Set-TargetResource @withCredentialsAndComputerParameter -ReplicationScope $testReplicationScope
                         Assert-MockCalled -CommandName New-CimSession -ParameterFilter { $computername -eq $withCredentialsAndComputerParameter.ComputerName -and $credential -eq $withCredentialsAndComputerParameter.Credential } -Scope It -Times 1 -Exactly
+                    }
+                    It 'Should call Remove-CimSession' {
+                        $withCredentialsAndComputerParameter = $testParams + @{
+                            ComputerName = $testComputerName
+                            Credential = $testCredential
+                        }
+                        Set-TargetResource @withCredentialsAndComputerParameter -ReplicationScope $testReplicationScope
+                        Assert-MockCalled -CommandName Remove-CimSession -Scope It -Times 1 -Exactly
                     }
                 }
             }

--- a/Tests/Unit/MSFT_xDnsServerADZone.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerADZone.Tests.ps1
@@ -93,15 +93,18 @@ try
                 $targetResource.Ensure | Should Be 'Absent'
             }
 
-            Context 'When a computername is not passed' {
-                It 'Should not call New-CimSession' {
+            Context 'When a computer name is not passed' {
+                BeforeAll {
                     Mock -CommandName New-CimSession
+                    Mock -CommandName Remove-CimSession
+                }
+
+                It 'Should not call New-CimSession' {
                     Get-TargetResource @testParams -ReplicationScope $testReplicationScope
                     Assert-MockCalled -CommandName New-CimSession -Scope It -Times 0 -Exactly
                 }
 
                 It 'Should not call Remove-CimSession' {
-                    Mock -CommandName Remove-CimSession
                     Get-TargetResource @testParams -ReplicationScope $testReplicationScope
                     Assert-MockCalled -CommandName Remove-CimSession -Scope It -Times 0 -Exactly
                 }
@@ -116,12 +119,16 @@ try
                 }
             }
 
-            Context 'When a computername is passed' {
+            Context 'When a computer name is passed' {
+                BeforeAll {
+                    Mock -CommandName New-CimSession -MockWith { New-MockObject -Type Microsoft.Management.Infrastructure.CimSession }
+                    Mock -CommandName Remove-CimSession
+                }
+
                 It 'Should call New-CimSession' {
                     $withComputerNameParameter = $testParams + @{
                         ComputerName = $testComputerName
                     }
-                    Mock -CommandName New-CimSession
                     Get-TargetResource @withComputerNameParameter -ReplicationScope $testReplicationScope
                     Assert-MockCalled -CommandName New-CimSession -ParameterFilter { $computername -eq $withComputerNameParameter.ComputerName } -Scope It -Times 1 -Exactly
                 }
@@ -129,18 +136,20 @@ try
                     $withComputerNameParameter = $testParams + @{
                         ComputerName = $testComputerName
                     }
-                    Mock -CommandName New-CimSession -MockWith { New-MockObject -Type Microsoft.Management.Infrastructure.CimSession }
-                    Mock -CommandName Remove-CimSession
                     Get-TargetResource @withComputerNameParameter -ReplicationScope $testReplicationScope
                     Assert-MockCalled -CommandName Remove-CimSession -Scope It -Times 1 -Exactly
                 }
                 Context 'When credentials are passed' {
+                    BeforeAll {
+                        Mock -CommandName New-CimSession -MockWith { New-MockObject -Type Microsoft.Management.Infrastructure.CimSession }
+                        Mock -CommandName Remove-CimSession
+                    }
+
                     It 'Should throw an exception indicating a computername must also be passed' {
                         $withCredentialsAndComputerParameter = $testParams + @{
                             ComputerName = $testComputerName
                             Credential = $testCredential
                         }
-                        Mock -CommandName New-CimSession
                         Get-TargetResource @withCredentialsAndComputerParameter -ReplicationScope $testReplicationScope
                         Assert-MockCalled -CommandName New-CimSession -ParameterFilter { $computername -eq $withCredentialsAndComputerParameter.ComputerName -and $credential -eq $withCredentialsAndComputerParameter.Credential } -Scope It -Times 1 -Exactly
                     }
@@ -261,28 +270,33 @@ try
             }
 
             Context 'When a computername is not passed' {
-                It 'Should not call New-CimSession' {
-                    Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                BeforeAll {
                     Mock -CommandName New-CimSession
+                    Mock -CommandName Remove-CimSession
+                    Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                }
+                It 'Should not call New-CimSession' {
                     Set-TargetResource @testParams -ReplicationScope $testReplicationScope
                     Assert-MockCalled -CommandName New-CimSession -Scope It -Times 0 -Exactly
                 }
 
                 It 'Should not call Remove-CimSession' {
-                    Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
-                    Mock -CommandName Remove-CimSession
                     Set-TargetResource @testParams -ReplicationScope $testReplicationScope
                     Assert-MockCalled -CommandName Remove-CimSession -Scope It -Times 0 -Exactly
                 }
             }
 
-            Context 'When a computername is passed' {
+            Context 'When a computer name is passed' {
+                BeforeAll {
+                    Mock -CommandName New-CimSession
+                    Mock -CommandName Remove-CimSession
+                    Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                }
+
                 It 'Should call New-CimSession' {
                     $withComputerNameParameter = $testParams + @{
                         ComputerName = $testComputerName
                     }
-                    Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
-                    Mock -CommandName New-CimSession
                     Set-TargetResource @withComputerNameParameter -ReplicationScope $testReplicationScope
                     Assert-MockCalled -CommandName New-CimSession -ParameterFilter { $computername -eq $withComputerNameParameter.ComputerName } -Scope It -Times 1 -Exactly
                 }
@@ -290,20 +304,21 @@ try
                     $withComputerNameParameter = $testParams + @{
                         ComputerName = $testComputerName
                     }
-                    Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
-                    Mock -CommandName New-CimSession -MockWith { New-MockObject -Type Microsoft.Management.Infrastructure.CimSession }
-                    Mock -CommandName Remove-CimSession
                     Set-TargetResource @withComputerNameParameter -ReplicationScope $testReplicationScope
                     Assert-MockCalled -CommandName Remove-CimSession -Scope It -Times 1 -Exactly
                 }
+
                 Context 'When credentials are passed' {
+                    BeforeAll {
+                        Mock -CommandName New-CimSession
+                        Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                    }
+
                     It 'Should throw an exception indicating a computername must also be passed' {
                         $withCredentialsAndComputerParameter = $testParams + @{
                             ComputerName = $testComputerName
                             Credential = $testCredential
                         }
-                        Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
-                        Mock -CommandName New-CimSession
                         Set-TargetResource @withCredentialsAndComputerParameter -ReplicationScope $testReplicationScope
                         Assert-MockCalled -CommandName New-CimSession -ParameterFilter { $computername -eq $withCredentialsAndComputerParameter.ComputerName -and $credential -eq $withCredentialsAndComputerParameter.Credential } -Scope It -Times 1 -Exactly
                     }

--- a/Tests/Unit/MSFT_xDnsServerADZone.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerADZone.Tests.ps1
@@ -26,35 +26,30 @@ try
 
     InModuleScope $Global:DSCResourceName {
         #region Pester Test Initialization
-        $testZoneName = 'example.com';
-        $testDynamicUpdate = 'Secure';
-        $testReplicationScope = 'Domain';
-        $testDirectoryPartitionName = "DomainDnsZones.$testZoneName";
-        $testParams = @{ Name = $testZoneName; }
+        $testZoneName = 'example.com'
+        $testDynamicUpdate = 'Secure'
+        $testReplicationScope = 'Domain'
+        $testComputerName = 'dnsserver.local'
+        $testCredential = New-Object System.Management.Automation.PSCredential 'DummyUser', (ConvertTo-SecureString 'DummyPassword' -AsPlainText -Force)
+        $testDirectoryPartitionName = "DomainDnsZones.$testZoneName"
+        $testParams = @{ Name = $testZoneName }
 
         $fakeDnsADZone = [PSCustomObject] @{
-            DistinguishedName = $null;
-            ZoneName = $testZoneName;
-            ZoneType = 'Primary';
-            DynamicUpdate = $testDynamicUpdate;
-            ReplicationScope = $testReplicationScope;
-            DirectoryPartitionName = $testDirectoryPartitionName;
-            ZoneFile = $null;
+            DistinguishedName = $null
+            ZoneName = $testZoneName
+            ZoneType = 'Primary'
+            DynamicUpdate = $testDynamicUpdate
+            ReplicationScope = $testReplicationScope
+            DirectoryPartitionName = $testDirectoryPartitionName
+            ZoneFile = $null
         }
 
         $fakePresentTargetResource = @{
             Name = $testZoneName
             DynamicUpdate = $testDynamicUpdate
-            ReplicationScope = $testReplicationScope;
-            DirectoryPartitionName = $testDirectoryPartitionName;
+            ReplicationScope = $testReplicationScope
+            DirectoryPartitionName = $testDirectoryPartitionName
             Ensure = 'Present'
-            CimSession = @{
-                Id = 1
-                Name = 'CimSession1'
-                InstanceId = 'a23d4d49-f588-407d-9b78-601cd74d8116'
-                ComputerName = 'localhost'
-                Protocol = 'WSMAN'
-            }
         }
 
         $fakeAbsentTargetResource = @{ Ensure = 'Absent' }
@@ -64,38 +59,92 @@ try
         Describe "$($Global:DSCResourceName)\Get-TargetResource" {
             function Get-DnsServerZone { }
 
-            Mock -CommandName 'Assert-Module' -MockWith { }
+            Mock -CommandName 'Assert-Module'
 
             It 'Returns a "System.Collections.Hashtable" object type with schema properties' {
-                $targetResource = Get-TargetResource @testParams -ReplicationScope $testReplicationScope;
-                $targetResource -is [System.Collections.Hashtable] | Should Be $true;
+                $targetResource = Get-TargetResource @testParams -ReplicationScope $testReplicationScope
+                $targetResource -is [System.Collections.Hashtable] | Should Be $true
 
-                $schemaFields = @('Name', 'DynamicUpdate', 'ReplicationScope', 'DirectoryPartitionName', 'Ensure');
-                ($Null -eq ($targetResource.Keys.GetEnumerator() | Where-Object -FilterScript { $schemaFields -notcontains $_ })) | Should Be $true;
+                $schemaFields = @('Name', 'DynamicUpdate', 'ReplicationScope', 'DirectoryPartitionName', 'Ensure')
+                ($Null -eq ($targetResource.Keys.GetEnumerator() | Where-Object -FilterScript { $schemaFields -notcontains $_ })) | Should Be $true
             }
 
             It 'Returns "Present" when DNS zone exists and "Ensure" = "Present"' {
-                Mock -CommandName Get-DnsServerZone -MockWith { return $fakeDnsADZone; }
-                $targetResource = Get-TargetResource @testParams -ReplicationScope $testReplicationScope;
-                $targetResource.Ensure | Should Be 'Present';
+                Mock -CommandName Get-DnsServerZone -MockWith { return $fakeDnsADZone }
+                $targetResource = Get-TargetResource @testParams -ReplicationScope $testReplicationScope
+                $targetResource.Ensure | Should Be 'Present'
             }
 
             It 'Returns "Absent" when DNS zone does not exists and "Ensure" = "Present"' {
-                Mock -CommandName Get-DnsServerZone -MockWith { }
-                $targetResource = Get-TargetResource @testParams -ReplicationScope $testReplicationScope;
-                $targetResource.Ensure | Should Be 'Absent';
+                Mock -CommandName Get-DnsServerZone
+                $targetResource = Get-TargetResource @testParams -ReplicationScope $testReplicationScope
+                $targetResource.Ensure | Should Be 'Absent'
             }
 
             It 'Returns "Present" when DNS zone exists and "Ensure" = "Absent"' {
-                Mock -CommandName Get-DnsServerZone -MockWith { return $fakeDnsADZone; }
-                $targetResource = Get-TargetResource @testParams -ReplicationScope $testReplicationScope -Ensure Absent;
-                $targetResource.Ensure | Should Be 'Present';
+                Mock -CommandName Get-DnsServerZone -MockWith { return $fakeDnsADZone }
+                $targetResource = Get-TargetResource @testParams -ReplicationScope $testReplicationScope -Ensure Absent
+                $targetResource.Ensure | Should Be 'Present'
             }
 
             It 'Returns "Absent" when DNS zone does not exist and "Ensure" = "Absent"' {
-                Mock -CommandName Get-DnsServerZone -MockWith { }
-                $targetResource = Get-TargetResource @testParams -ReplicationScope $testReplicationScope -Ensure Absent;
-                $targetResource.Ensure | Should Be 'Absent';
+                Mock -CommandName Get-DnsServerZone
+                $targetResource = Get-TargetResource @testParams -ReplicationScope $testReplicationScope -Ensure Absent
+                $targetResource.Ensure | Should Be 'Absent'
+            }
+
+            Context 'When a computername is not passed' {
+                It 'Should not call New-CimSession' {
+                    Mock -CommandName New-CimSession
+                    Get-TargetResource @testParams -ReplicationScope $testReplicationScope
+                    Assert-MockCalled -CommandName New-CimSession -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should not call Remove-CimSession' {
+                    Mock -CommandName Remove-CimSession
+                    Get-TargetResource @testParams -ReplicationScope $testReplicationScope
+                    Assert-MockCalled -CommandName Remove-CimSession -Scope It -Times 0 -Exactly
+                }
+
+                Context 'When credential is passed' {
+                    It 'Should throw an exception indicating a computername must also be passed' {
+                        $withCredentialsParameter = $testParams + @{
+                            Credential = $testCredential
+                        }
+                        { Get-TargetResource @withCredentialsParameter -ReplicationScope $testReplicationScope } | Should -Throw 
+                    }
+                }
+            }
+
+            Context 'When a computername is passed' {
+                It 'Should call New-CimSession' {
+                    $withComputerNameParameter = $testParams + @{
+                        ComputerName = $testComputerName
+                    }
+                    Mock -CommandName New-CimSession
+                    Get-TargetResource @withComputerNameParameter -ReplicationScope $testReplicationScope
+                    Assert-MockCalled -CommandName New-CimSession -ParameterFilter { $computername -eq $withComputerNameParameter.ComputerName } -Scope It -Times 1 -Exactly
+                }
+                It 'Should call Remove-CimSession' {
+                    $withComputerNameParameter = $testParams + @{
+                        ComputerName = $testComputerName
+                    }
+                    Mock -CommandName New-CimSession -MockWith { New-MockObject -Type Microsoft.Management.Infrastructure.CimSession }
+                    Mock -CommandName Remove-CimSession
+                    Get-TargetResource @withComputerNameParameter -ReplicationScope $testReplicationScope
+                    Assert-MockCalled -CommandName Remove-CimSession -Scope It -Times 1 -Exactly
+                }
+                Context 'When credentials are passed' {
+                    It 'Should throw an exception indicating a computername must also be passed' {
+                        $withCredentialsAndComputerParameter = $testParams + @{
+                            ComputerName = $testComputerName
+                            Credential = $testCredential
+                        }
+                        Mock -CommandName New-CimSession
+                        Get-TargetResource @withCredentialsAndComputerParameter -ReplicationScope $testReplicationScope
+                        Assert-MockCalled -CommandName New-CimSession -ParameterFilter { $computername -eq $withCredentialsAndComputerParameter.ComputerName -and $credential -eq $withCredentialsAndComputerParameter.Credential } -Scope It -Times 1 -Exactly
+                    }
+                }
             }
         }
         #endregion
@@ -106,59 +155,59 @@ try
             function Get-DnsServerZone { }
             
             It 'Returns a "System.Boolean" object type' {
-                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource; }
-                $targetResource =  Test-TargetResource @testParams -ReplicationScope $testReplicationScope;
-                $targetResource -is [System.Boolean] | Should Be $true;
+                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                $targetResource =  Test-TargetResource @testParams -ReplicationScope $testReplicationScope
+                $targetResource -is [System.Boolean] | Should Be $true
             }
 
             It 'Passes when DNS zone exists and "Ensure" = "Present"' {
-                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource; }
-                Test-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope | Should Be $true;
+                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                Test-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope | Should Be $true
             }
 
             It 'Passes when DNS zone does not exist and "Ensure" = "Absent"' {
-                Mock -CommandName Get-TargetResource -MockWith {  }
-                Test-TargetResource @testParams -Ensure Absent -ReplicationScope $testReplicationScope | Should Be $true;
+                Mock -CommandName Get-TargetResource
+                Test-TargetResource @testParams -Ensure Absent -ReplicationScope $testReplicationScope | Should Be $true
             }
 
             It 'Passes when DNS zone "DynamicUpdate" is correct' {
-                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource; }
-                Test-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope -DynamicUpdate $testDynamicUpdate | Should Be $true;
+                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                Test-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope -DynamicUpdate $testDynamicUpdate | Should Be $true
             }
 
             It 'Passes when DNS zone "ReplicationScope" is correct' {
-                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource; }
-                Test-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope | Should Be $true;
+                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                Test-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope | Should Be $true
             }
 
             It 'Passes when DNS zone "DirectoryPartitionName" is correct' {
-                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource; }
-                Test-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope -DirectoryPartitionName $testDirectoryPartitionName | Should Be $true;
+                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                Test-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope -DirectoryPartitionName $testDirectoryPartitionName | Should Be $true
             }
 
             It 'Fails when DNS zone exists and "Ensure" = "Absent"' {
-                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource; }
-                Test-TargetResource @testParams -Ensure Absent -ReplicationScope $testReplicationScope | Should Be $false;
+                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                Test-TargetResource @testParams -Ensure Absent -ReplicationScope $testReplicationScope | Should Be $false
             }
 
             It 'Fails when DNS zone does not exist and "Ensure" = "Present"' {
-                Mock -CommandName Get-TargetResource -MockWith { }
-                Test-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope | Should Be $false;
+                Mock -CommandName Get-TargetResource
+                Test-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope | Should Be $false
             }
 
             It 'Fails when DNS zone "DynamicUpdate" is incorrect' {
-                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource; }
-                Test-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope -DynamicUpdate 'NonsecureAndSecure' | Should Be $false;
+                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                Test-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope -DynamicUpdate 'NonsecureAndSecure' | Should Be $false
             }
 
             It 'Fails when DNS zone "ReplicationScope" is incorrect' {
-                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource; }
-                Test-TargetResource @testParams -Ensure Present -ReplicationScope 'Forest' | Should Be $false;
+                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                Test-TargetResource @testParams -Ensure Present -ReplicationScope 'Forest' | Should Be $false
             }
 
             It 'Fails when DNS zone "DirectoryPartitionName" is incorrect' {
-                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource; }
-                Test-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope -DirectoryPartitionName 'IncorrectDirectoryPartitionName' | Should Be $false;
+                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                Test-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope -DirectoryPartitionName 'IncorrectDirectoryPartitionName' | Should Be $false
             }
         }
         #endregion
@@ -178,37 +227,87 @@ try
 
             It 'Calls "Add-DnsServerPrimaryZone" when DNS zone does not exist and "Ensure" = "Present"' {
                 Mock -CommandName Get-TargetResource -MockWith { return $fakeAbsentTargetResource }
-                Mock -CommandName Add-DnsServerPrimaryZone -ParameterFilter { $Name -eq $testZoneName } -MockWith { }
-                Set-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope -DynamicUpdate $testDynamicUpdate;
-                Assert-MockCalled -CommandName Add-DnsServerPrimaryZone -ParameterFilter { $Name -eq $testZoneName } -Scope It;
+                Mock -CommandName Add-DnsServerPrimaryZone -ParameterFilter { $Name -eq $testZoneName }
+                Set-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope -DynamicUpdate $testDynamicUpdate
+                Assert-MockCalled -CommandName Add-DnsServerPrimaryZone -ParameterFilter { $Name -eq $testZoneName } -Scope It
             }
 
             It 'Calls "Remove-DnsServerZone" when DNS zone does exist and "Ensure" = "Absent"' {
-                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource; }
-                Mock -CommandName Remove-DnsServerZone -MockWith { }
-                Set-TargetResource @testParams -Ensure Absent -ReplicationScope $testReplicationScope -DynamicUpdate $testDynamicUpdate;
-                Assert-MockCalled -CommandName Remove-DnsServerZone -Scope It;
+                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                Mock -CommandName Remove-DnsServerZone
+                Set-TargetResource @testParams -Ensure Absent -ReplicationScope $testReplicationScope -DynamicUpdate $testDynamicUpdate
+                Assert-MockCalled -CommandName Remove-DnsServerZone -Scope It
             }
 
             It 'Calls "Set-DnsServerPrimaryZone" when DNS zone "DynamicUpdate" is incorrect' {
-                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource; }
-                Mock -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $DynamicUpdate -eq 'NonsecureAndSecure' } -MockWith { }
-                Set-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope -DynamicUpdate 'NonsecureAndSecure';
-                Assert-MockCalled -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $DynamicUpdate -eq 'NonsecureAndSecure' } -Scope It;
+                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                Mock -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $DynamicUpdate -eq 'NonsecureAndSecure' }
+                Set-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope -DynamicUpdate 'NonsecureAndSecure'
+                Assert-MockCalled -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $DynamicUpdate -eq 'NonsecureAndSecure' } -Scope It
             }
 
             It 'Calls "Set-DnsServerPrimaryZone" when DNS zone "ReplicationScope" is incorrect' {
-                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource; }
-                Mock -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $ReplicationScope -eq 'Forest' } -MockWith { }
-                Set-TargetResource @testParams -Ensure Present -ReplicationScope 'Forest';
-                Assert-MockCalled -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $ReplicationScope -eq 'Forest' } -Scope It;
+                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                Mock -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $ReplicationScope -eq 'Forest' }
+                Set-TargetResource @testParams -Ensure Present -ReplicationScope 'Forest'
+                Assert-MockCalled -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $ReplicationScope -eq 'Forest' } -Scope It
             }
 
             It 'Calls "Set-DnsServerPrimaryZone" when DNS zone "DirectoryPartitionName" is incorrect' {
-                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource; }
-                Mock -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $DirectoryPartitionName -eq 'IncorrectDirectoryPartitionName' } -MockWith { }
-                Set-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope -DirectoryPartitionName 'IncorrectDirectoryPartitionName';
-                Assert-MockCalled -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $DirectoryPartitionName -eq 'IncorrectDirectoryPartitionName' } -Scope It;
+                Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                Mock -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $DirectoryPartitionName -eq 'IncorrectDirectoryPartitionName' }
+                Set-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope -DirectoryPartitionName 'IncorrectDirectoryPartitionName'
+                Assert-MockCalled -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $DirectoryPartitionName -eq 'IncorrectDirectoryPartitionName' } -Scope It
+            }
+
+            Context 'When a computername is not passed' {
+                It 'Should not call New-CimSession' {
+                    Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                    Mock -CommandName New-CimSession
+                    Set-TargetResource @testParams -ReplicationScope $testReplicationScope
+                    Assert-MockCalled -CommandName New-CimSession -Scope It -Times 0 -Exactly
+                }
+
+                It 'Should not call Remove-CimSession' {
+                    Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                    Mock -CommandName Remove-CimSession
+                    Set-TargetResource @testParams -ReplicationScope $testReplicationScope
+                    Assert-MockCalled -CommandName Remove-CimSession -Scope It -Times 0 -Exactly
+                }
+            }
+
+            Context 'When a computername is passed' {
+                It 'Should call New-CimSession' {
+                    $withComputerNameParameter = $testParams + @{
+                        ComputerName = $testComputerName
+                    }
+                    Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                    Mock -CommandName New-CimSession
+                    Set-TargetResource @withComputerNameParameter -ReplicationScope $testReplicationScope
+                    Assert-MockCalled -CommandName New-CimSession -ParameterFilter { $computername -eq $withComputerNameParameter.ComputerName } -Scope It -Times 1 -Exactly
+                }
+                It 'Should call Remove-CimSession' {
+                    $withComputerNameParameter = $testParams + @{
+                        ComputerName = $testComputerName
+                    }
+                    Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                    Mock -CommandName New-CimSession -MockWith { New-MockObject -Type Microsoft.Management.Infrastructure.CimSession }
+                    Mock -CommandName Remove-CimSession
+                    Set-TargetResource @withComputerNameParameter -ReplicationScope $testReplicationScope
+                    Assert-MockCalled -CommandName Remove-CimSession -Scope It -Times 1 -Exactly
+                }
+                Context 'When credentials are passed' {
+                    It 'Should throw an exception indicating a computername must also be passed' {
+                        $withCredentialsAndComputerParameter = $testParams + @{
+                            ComputerName = $testComputerName
+                            Credential = $testCredential
+                        }
+                        Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                        Mock -CommandName New-CimSession
+                        Set-TargetResource @withCredentialsAndComputerParameter -ReplicationScope $testReplicationScope
+                        Assert-MockCalled -CommandName New-CimSession -ParameterFilter { $computername -eq $withCredentialsAndComputerParameter.ComputerName -and $credential -eq $withCredentialsAndComputerParameter.Credential } -Scope It -Times 1 -Exactly
+                    }
+                }
             }
         }
         #endregion

--- a/Tests/Unit/MSFT_xDnsServerForwarder.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerForwarder.Tests.ps1
@@ -1,4 +1,4 @@
-﻿$Global:DSCModuleName      = 'xDnsServer'
+$Global:DSCModuleName      = 'xDnsServer'
 $Global:DSCResourceName    = 'MSFT_xDnsServerForwarder'
 
 #region HEADER

--- a/Tests/Unit/MSFT_xDnsServerZoneTransfer.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerZoneTransfer.Tests.ps1
@@ -1,4 +1,4 @@
-﻿$Global:DSCModuleName      = 'xDnsServer'
+$Global:DSCModuleName      = 'xDnsServer'
 $Global:DSCResourceName    = 'MSFT_xDnsServerZoneTransfer'
 
 #region HEADER


### PR DESCRIPTION
This is an attempt to resolve #53 .  I've done the following:

1. New up a cim session only when computername is passed in as a parameter.
   - **This logic is duplicated in Get-TargetResource & Set-TargetResource.  Is there a cleaner way?** 
1. Throw an exception in Get-TargetResource when Credentials are passed in but no ComputerName is passed since Passing Credentials without a computername makes no sense.
    - **What is the correct way of throwing a dsc exception because of invalid use of parameters?**
    - **Do i need to do this same validation in the Set-TargetResource function?**
1. Anytime a new-cimsession is created be sure to cleanup with a call to remove-cimsession
1. Added tests to verify the above statements
    - **Is there a cleaner way to write the tests?**

/cc @johlju

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdnsserver/62)
<!-- Reviewable:end -->
