### PR TITLE
xDnsServerSetting: Add read-only property DsAvailable

### DIFF
--- a/DSCResources/MSFT_xDnsServerSetting/MSFT_xDnsServerSetting.schema.mof
+++ b/DSCResources/MSFT_xDnsServerSetting/MSFT_xDnsServerSetting.schema.mof
@@ -47,5 +47,5 @@ class MSFT_xDnsServerSetting : OMI_BaseResource
     [Write, Description("Restricts the type of records that can be dynamically updated on the server, used in addition to the AllowUpdate settings on Server and Zone objects.")] Uint32 UpdateOptions;
     [Write, Description("Specifies whether the DNS Server writes NS and SOA records to the authority section on successful response.")] Boolean WriteAuthorityNS;
     [Write, Description("Time, in seconds, the DNS Server waits for a successful TCP connection to a remote server when attempting a zone transfer.")] Uint32 XfrConnectTimeout;
+    [Read, Description("Indicates whether there is an available DS on the DNS Server.")] Boolean DsAvailable;
 };
-

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **UpdateOptions**: Restricts the type of records that can be dynamically updated on the server, used in addition to the AllowUpdate settings on Server and Zone objects.
 * **WriteAuthorityNS**: Specifies whether the DNS Server writes NS and SOA records to the authority section on successful response.
 * **XfrConnectTimeout**: Time, in seconds, the DNS Server waits for a successful TCP connection to a remote server when attempting a zone transfer.
+* **DsAvailable**: Indicates whether there is an available DS on the DNS Server. This is a read-only property.
 
 ## Versions
 
@@ -142,6 +143,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   regardless of connecting to a remote machine or the local machine.  Now CimSessions are only utilized when a computername or
   computername and credential are used. ([issue #53](https://github.com/PowerShell/xDnsServer/issues/53)).
 * Fixed all PSSA rule warnings.
+* Fix DsAvailaable key missing ([#66](https://github.com/PowerShell/xDnsServer/issues/66).
 
 ### 1.9.0.0
 

--- a/Tests/Unit/MSFT_xDnsServerSetting.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerSetting.Tests.ps1
@@ -159,6 +159,9 @@ try
         $mockGetDnsDiag = @{
             FilterIPAddressList = '10.1.1.1','10.0.0.1'
         }
+        $mockReadOnlyProperties = @{
+            DsAvailable = $true
+        }
         #endregion Pester Test Initialization
 
         #region Example state 1
@@ -176,9 +179,13 @@ try
                         {
                             $getResult[$key] | Should be $mockGetCimInstance[$key]
                         }
-                        elseIf ($key -eq 'LogIPFilterList')
+                        elseif ($key -eq 'LogIPFilterList')
                         {
                             $getResult[$key] | Should be $mockGetDnsDiag[$key]
+                        }
+                        if ($key -eq 'DsAvailable')
+                        {
+                            $getResult[$key] | Should Be $mockReadOnlyProperties[$key]
                         }
                     }
                 }


### PR DESCRIPTION
Fix for issue https://github.com/PowerShell/xDnsServer/issues/66

The DsAvailable property is a read-only output property on the xDnsServerSetting resource.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdnsserver/69)
<!-- Reviewable:end -->
