### PR TITLE
Enhancements to Test-DscParameterState as in NetworkingDsc

### DIFF
--- a/Modules/Helper/Helper.psm1
+++ b/Modules/Helper/Helper.psm1
@@ -70,15 +70,15 @@ function New-TerminatingError
     (
         [Parameter(Mandatory = $true)]
         [System.String]
-        $errorId,
+        $ErrorId,
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $errorMessage,
+        $ErrorMessage,
 
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.ErrorCategory]
-        $errorCategory
+        $ErrorCategory
     )
 
     $exception = New-Object System.InvalidOperationException $errorMessage
@@ -100,7 +100,7 @@ function Assert-Module
     if(-not (Get-Module -Name $Name -ListAvailable))
     {
         $errorMsg = $LocalizedData.RoleNotFound -f $Name
-        New-TerminatingError -errorId ModuleNotFound -errorMessage $errorMsg -errorCategory ObjectNotFound
+        New-TerminatingError -ErrorId ModuleNotFound -ErrorMessage $errorMsg -ErrorCategory ObjectNotFound
     }
 }
 

--- a/Modules/Helper/Helper.psm1
+++ b/Modules/Helper/Helper.psm1
@@ -69,11 +69,11 @@ function New-TerminatingError
     param
     (
         [Parameter(Mandatory = $true)]
-        [String]
+        [System.String]
         $errorId,
 
         [Parameter(Mandatory = $true)]
-        [String]
+        [System.String]
         $errorMessage,
 
         [Parameter(Mandatory = $true)]
@@ -93,26 +93,26 @@ function Assert-Module
     param
     (
         [Parameter(Mandatory = $true)]
-        [string]
+        [System.String]
         $Name
     )
 
     if(-not (Get-Module -Name $Name -ListAvailable))
     {
-        $errorMsg = $($LocalizedData.RoleNotFound) -f $Name
-        New-TerminatingError -errorId 'ModuleNotFound' -errorMessage $errorMsg -errorCategory ObjectNotFound
+        $errorMsg = $LocalizedData.RoleNotFound -f $Name
+        New-TerminatingError -errorId ModuleNotFound -errorMessage $errorMsg -errorCategory ObjectNotFound
     }
 }
 
 #Internal function to remove all common parameters from $PSBoundParameters before it is passed to Set-CimInstance
 function Remove-CommonParameter
 {
-    [OutputType([hashtable])]
-    [cmdletbinding()]
+    [OutputType([System.Collections.Hashtable])]
+    [CmdletBinding()]
     param
     (
         [Parameter(Mandatory = $true)]
-        [hashtable]
+        [System.Collections.Hashtable]
         $Hashtable
     )
 
@@ -191,7 +191,7 @@ function Test-DscParameterState
     }
 
     if ($DesiredValues -is [Microsoft.Management.Infrastructure.CimInstance] -or
-    $DesiredValues -is [Microsoft.Management.Infrastructure.CimInstance[]])
+        $DesiredValues -is [Microsoft.Management.Infrastructure.CimInstance[]])
     {
         $DesiredValues = ConvertTo-HashTable -CimInstance $DesiredValues
     }

--- a/README.md
+++ b/README.md
@@ -215,12 +215,12 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 * Copied enhancements to Test-DscParameterState from NetworkingDsc
 * Put the helper module to its own folder
+* Copied enhancements to Test-DscParameterState from NetworkingDsc
+* Put the helper module to its own folder
 
 ### 1.13.0.0
 
 * Added resource xDnsServerConditionalForwarder
-* Copied enhancements to Test-DscParameterState from NetworkingDsc
-* Put the helper module to its own folder
 * Added xDnsServerRootHint resource
 * Added xDnsServerDiagnostics resource to this module.
 

--- a/README.md
+++ b/README.md
@@ -217,11 +217,11 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * Put the helper module to its own folder
 * Copied enhancements to Test-DscParameterState from NetworkingDsc
 * Put the helper module to its own folder
+* Added xDnsServerRootHint resource
 
 ### 1.13.0.0
 
 * Added resource xDnsServerConditionalForwarder
-* Added xDnsServerRootHint resource
 * Added xDnsServerDiagnostics resource to this module.
 
 ### 1.12.0.0


### PR DESCRIPTION
#### Pull Request (PR) description
Enhancements to Test-DscParameterState as in NetworkingDsc. The new features in the function are required for the upcoming xDnsServerRootHint resource.

This is just a copy of the changes added to NetworkingDsc that have been already merged by @PlagueHO in PowerShell/NetworkingDsc#402. It would be nice if we don't have to go through the full code review again.

#### This Pull Request (PR) fixes the following issues
This is not related to an open issue.

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdnsserver/97)
<!-- Reviewable:end -->
