### PR TITLE
xDnsServerForwarder: Ignore UseRootHint in test function

### DIFF
--- a/DSCResources/MSFT_xDnsServerForwarder/MSFT_xDnsServerForwarder.psm1
+++ b/DSCResources/MSFT_xDnsServerForwarder/MSFT_xDnsServerForwarder.psm1
@@ -91,8 +91,12 @@ function Test-TargetResource
             return $false
         }
     }
-    if($currentConfiguration.UseRootHint -ne $UseRootHint){
-        return $false
+    if ($PSBoundParameters.ContainsKey('UseRootHint'))
+    {
+        if($currentConfiguration.UseRootHint -ne $UseRootHint)
+        {
+            return $false
+        }
     }
 
     return $true

--- a/DSCResources/MSFT_xDnsServerForwarder/MSFT_xDnsServerForwarder.psm1
+++ b/DSCResources/MSFT_xDnsServerForwarder/MSFT_xDnsServerForwarder.psm1
@@ -93,7 +93,7 @@ function Test-TargetResource
     }
     if ($PSBoundParameters.ContainsKey('UseRootHint'))
     {
-        if($currentConfiguration.UseRootHint -ne $UseRootHint)
+        if ($currentConfiguration.UseRootHint -ne $UseRootHint)
         {
             return $false
         }

--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ Requires Windows Server 2016 onwards
 
 ### Unreleased
 
+* Fixed: Ignore UseRootHint in xDnsServerForwarder test function if it was not
+  specified in the resource [Claudio Spizzi (@claudiospizzi)](https://github.com/claudiospizzi)
+
 ### 1.14.0.0
 
 * Copied enhancements to Test-DscParameterState from NetworkingDsc

--- a/Tests/Unit/MSFT_xDnsServerForwarder.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerForwarder.Tests.ps1
@@ -36,9 +36,17 @@ try
             IPAddresses = $forwarders
             UseRootHint = $UseRootHint
         }
+        $testParamLimited = @{
+            IsSingleInstance = 'Yes'
+            IPAddresses = $forwarders
+        }
         $fakeDNSForwarder = @{
             IPAddress = $forwarders
             UseRootHint = $UseRootHint
+        }
+        $fakeUseRootHint = @{
+            IPAddress = $forwarders
+            UseRootHint = -not $UseRootHint
         }
         #endregion
 
@@ -81,10 +89,16 @@ try
                 Test-TargetResource @testParams | Should Be $true
             }
 
+            It 'Passes when forwarders match but root hint do not and are not spcified' {
+                Mock -CommandName Get-DnsServerForwarder -MockWith {return $fakeUseRootHint}
+                Test-TargetResource @testParamLimited | Should Be $true
+            }
+
             It "Fails when forwarders don't match" {
                 Mock -CommandName Get-DnsServerForwarder -MockWith {return @{IPAddress = @(); UseRootHint = $true}}
                 Test-TargetResource @testParams | Should Be $false
             }
+
             It "Fails when UseRootHint don't match" {
                 Mock -CommandName Get-DnsServerForwarder -MockWith {return @{IPAddress = $fakeDNSForwarder.IpAddress; UseRootHint = $false}}
                 Test-TargetResource @testParams | Should Be $false


### PR DESCRIPTION
#### Pull Request (PR) description

If the `UseRootHint` was not specified in the resource, the default will be `$false`. If we now have the DNS Server default configuration actually set to `$true`, the resource will never be in the desired state.

Proposed solution: Only test the root hints if they were specified.

#### Task list

- [X] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [X] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdnsserver/104)
<!-- Reviewable:end -->
