### PR TITLE
xDnsServerADZone: ReplicationScope must be 'Custom' if DirectoryPartitionName is Specified

### DIFF
--- a/Tests/Unit/MSFT_xDnsServerADZone.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsServerADZone.Tests.ps1
@@ -274,8 +274,17 @@ try
             It 'Calls "Set-DnsServerPrimaryZone" when DNS zone "DirectoryPartitionName" is incorrect' {
                 Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
                 Mock -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $DirectoryPartitionName -eq 'IncorrectDirectoryPartitionName' }
-                Set-TargetResource @testParams -Ensure Present -ReplicationScope $testReplicationScope -DirectoryPartitionName 'IncorrectDirectoryPartitionName'
+                Set-TargetResource @testParams -Ensure Present -ReplicationScope 'Custom' -DirectoryPartitionName 'IncorrectDirectoryPartitionName'
                 Assert-MockCalled -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $DirectoryPartitionName -eq 'IncorrectDirectoryPartitionName' } -Scope It
+            }
+
+            Context 'When a DirectoryPartitionName is specified and ReplicationScope is not ''Custom''' {
+                It 'Should throw the correct exception' {
+                    Mock -CommandName Get-TargetResource -MockWith { return $fakePresentTargetResource }
+                    Mock -CommandName Set-DnsServerPrimaryZone -ParameterFilter { $DirectoryPartitionName -eq 'IncorrectDirectoryPartitionName' }
+                    { Set-TargetResource @testParams -Ensure Present -ReplicationScope 'Domain' `
+                        -DirectoryPartitionName 'IncorrectDirectoryPartitionName' } | Should -Throw $LocalizedData.DirectoryPartitionReplicationScopeError
+                }
             }
 
             Context 'When a computer name is not passed' {


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds code to the `xDnsServerADZone` resource to check that the `ReplicationScope` parameter has been set to `Custom` if `DirectoryPartitionName` is specified, and raises an exception if it hasn't.

It also enforces the `ReplicationScope` parameter being passed to `Set-DnsServerPrimaryZone` if `DirectoryPartitionName` has changed.

#### This Pull Request (PR) fixes the following issues

- Fixes #110

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [ ] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
